### PR TITLE
feat: add import_site_configs() for version-aware site fixture import

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -173,6 +173,7 @@ function post_setup() {
   _progress " ├─ Import data"
     import_xml_data
     import_sql_data
+    import_site_configs
   _done
   _progress " ├─ Update TYPO3"
     update_typo3
@@ -363,6 +364,38 @@ function import_sql_data() {
             mysql -h db -u root -p"root" $DATABASE < "$DATA_FILE"
         else
           message yellow "No SQL files found in $FIXTURE_DIR. Import will be skipped."
+        fi
+    done
+}
+
+# Function to import site configuration YAML fixtures.
+# It copies each directory under Tests/Acceptance/Fixtures/sites/ to the
+# TYPO3 site configuration path for the current version, replacing
+# VERSION_PLACEHOLDER with the actual version number in the config.yaml.
+function import_site_configs() {
+    FIXTURE_DIR="/var/www/html/Tests/Acceptance/Fixtures/sites"
+
+    if [ ! -d "$FIXTURE_DIR" ]; then
+        return
+    fi
+
+    if [ "$VERSION" == "11" ] || [ "$VERSION" == "12" ]; then
+        TARGET_BASE="/var/www/html/.Build/$VERSION/public/typo3conf/sites"
+    else
+        TARGET_BASE="/var/www/html/.Build/$VERSION/config/sites"
+    fi
+
+    mkdir -p "$TARGET_BASE"
+
+    for SITE_DIR in "$FIXTURE_DIR"/*/; do
+        if [ -d "$SITE_DIR" ]; then
+            SITE_NAME=$(basename "$SITE_DIR")
+            message yellow "Importing site config $SITE_NAME..."
+            mkdir -p "$TARGET_BASE/$SITE_NAME"
+            cp -r "$SITE_DIR"* "$TARGET_BASE/$SITE_NAME/"
+            if [ -f "$TARGET_BASE/$SITE_NAME/config.yaml" ]; then
+                sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" "$TARGET_BASE/$SITE_NAME/config.yaml"
+            fi
         fi
     done
 }

--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -379,11 +379,7 @@ function import_site_configs() {
         return
     fi
 
-    if [ "$VERSION" == "11" ] || [ "$VERSION" == "12" ]; then
-        TARGET_BASE="/var/www/html/.Build/$VERSION/public/typo3conf/sites"
-    else
-        TARGET_BASE="/var/www/html/.Build/$VERSION/config/sites"
-    fi
+    TARGET_BASE="/var/www/html/.Build/$VERSION/config/sites"
 
     mkdir -p "$TARGET_BASE"
 


### PR DESCRIPTION
## Summary

- Add `import_site_configs()` function that copies site configuration YAML fixtures from `Tests/Acceptance/Fixtures/sites/` into the correct TYPO3 site config path
- Version-aware path detection: `typo3conf/sites` for v11/v12, `config/sites` for v13+
- Supports `VERSION_PLACEHOLDER` substitution in `config.yaml`
- Silently skips if no fixtures directory exists — no impact on projects that don't use it
- Called automatically during `post_setup()` import data step

## Changes

- `.setup/scripts/utils.sh` - Add `import_site_configs()` function and wire it into `post_setup()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced setup automation to import site fixture configurations into version-specific TYPO3 directories during post-setup initialization.
  * Added support for different configuration paths based on TYPO3 version (11, 12, and others).
  * Improved configuration management with automatic version-specific placeholder replacement in imported configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->