### PR TITLE
feat: add run_fixture_scripts() for shell-based fixture seeding

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -173,6 +173,7 @@ function post_setup() {
   _progress " ├─ Import data"
     import_xml_data
     import_sql_data
+    run_fixture_scripts
   _done
   _progress " ├─ Update TYPO3"
     update_typo3
@@ -363,6 +364,22 @@ function import_sql_data() {
             mysql -h db -u root -p"root" $DATABASE < "$DATA_FILE"
         else
           message yellow "No SQL files found in $FIXTURE_DIR. Import will be skipped."
+        fi
+    done
+}
+
+# Function to run shell script fixtures from Tests/Acceptance/Fixtures/.
+# Executes any *.sh scripts found in the fixture directory. Failures are
+# logged but do not abort the setup, so external services (e.g. Solr,
+# Elasticsearch) that are not yet reachable during early provisioning
+# do not break the installation.
+function run_fixture_scripts() {
+    FIXTURE_DIR="/var/www/html/Tests/Acceptance/Fixtures"
+
+    for SCRIPT in "$FIXTURE_DIR"/*.sh; do
+        if [ -f "$SCRIPT" ]; then
+            message yellow "Running fixture script $(basename "$SCRIPT")..."
+            bash "$SCRIPT" || message red "Fixture script $(basename "$SCRIPT") failed (continuing)"
         fi
     done
 }


### PR DESCRIPTION
## Summary

- Add `run_fixture_scripts()` function that executes all `*.sh` scripts in `Tests/Acceptance/Fixtures/` during setup
- Failures are logged but do not abort the installation, so external services (Solr, Elasticsearch, etc.) that are unavailable during early provisioning do not break the setup
- Called automatically during `post_setup()` import data step
- No impact on projects without shell fixtures — the loop simply finds no matching files

## Changes

- `.setup/scripts/utils.sh` - Add `run_fixture_scripts()` function and wire it into `post_setup()`