### PR TITLE
fix: harden setup script and addon lifecycle commands

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -362,11 +362,13 @@ function import_sql_data() {
     for DATA_FILE in "$FIXTURE_DIR"/*.sql; do
         if [ -f "$DATA_FILE" ]; then
             message yellow "Importing $DATA_FILE..."
-            mysql -h db -u root -p"root" $DATABASE < "$DATA_FILE"
-        else
-          message yellow "No SQL files found in $FIXTURE_DIR. Import will be skipped."
+            mysql -h db -u root -p"root" "$DATABASE" < "$DATA_FILE"
         fi
     done
+
+    if ! ls "$FIXTURE_DIR"/*.sql >/dev/null 2>&1; then
+        message yellow "No SQL files found in $FIXTURE_DIR. Skipping SQL import."
+    fi
 }
 
 # Function to import site configuration YAML fixtures.

--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -155,7 +155,7 @@ function pre_setup() {
 function post_setup() {
   prepare_acceptance_testing
 
-  cd $BASE_PATH
+  cd "$BASE_PATH" || { message red "Failed to change to $BASE_PATH"; return 1; }
   TYPO3_INSTALL_DB_DBNAME=$DATABASE
 
   _progress " ├─ Setup TYPO3"
@@ -269,7 +269,7 @@ function setup_composer() {
 # and configures various TYPO3 settings such as debug mode, error display, trusted hosts pattern,
 # mail transport, and graphics processor.
 function setup_typo3() {
-    cd $BASE_PATH
+    cd "$BASE_PATH" || { message red "Failed to change to $BASE_PATH"; return 1; }
     export TYPO3_INSTALL_DB_DBNAME=$DATABASE
     $TYPO3_BIN configuration:set 'BE/debug' 1
     $TYPO3_BIN configuration:set 'FE/debug' 1

--- a/.setup/templates/index.php
+++ b/.setup/templates/index.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 $extensionKey = getenv('EXTENSION_NAME');
 $typo3AdminUser = getenv('TYPO3_SETUP_ADMIN_USERNAME');
 $typo3AdminPassword = getenv('TYPO3_SETUP_ADMIN_PASSWORD');

--- a/install.yaml
+++ b/install.yaml
@@ -115,5 +115,5 @@ post_install_actions:
     echo "For more information, see the https://github.com/konradmichalik/ddev-typo3-multi-version-extension/blob/main/README.md file."
 
 removal_actions:
-  - rm ${DDEV_APPROOT}/.ddev/config.typo3-setup.yaml
-  - rm -f ${DDEV_APPROOT}/.ddev/.setup/
+  - rm -f ${DDEV_APPROOT}/.ddev/config.typo3-setup.yaml
+  - rm -rf ${DDEV_APPROOT}/.ddev/.setup/


### PR DESCRIPTION
## Summary

- Fail fast when `cd "$BASE_PATH"` cannot enter the build directory instead of silently running follow-up commands in the wrong working directory
- Quote `$DATABASE` in the SQL fixture import and emit the *no fixtures* message after the loop (matching `import_xml_data`) instead of repeating it for every non-file glob match
- Declare `strict_types=1` in the launcher template so consumer extensions enforcing PSR-12 do not get downstream lint findings
- Make addon removal idempotent: the config file is now removed with `-f` and the `.setup/` directory with `-rf`, so reinstall/remove no longer breaks on a missing or already-cleaned-up state

## Changes

- `.setup/scripts/utils.sh` — guard `cd "$BASE_PATH"` in `post_setup` and `setup_typo3`; fix `import_sql_data` skip logic and quote `$DATABASE`
- `.setup/templates/index.php` — add `declare(strict_types=1);`
- `install.yaml` — `removal_actions` use idempotent flags

## Context

Findings originally surfaced by CodeRabbit on [konradmichalik/typo3-letter-avatar#56](https://github.com/konradmichalik/typo3-letter-avatar/pull/56) where they were deferred upstream because the affected files are shipped by this addon.
