### PR TITLE
feat: surface install errors and add -v/--verbose flag

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -46,16 +46,39 @@ function _progress() {
     fi
 }
 
+# Stop the spinner (if running) and restore the original stdout/stderr file
+# descriptors. Idempotent — safe to call when no progress region is active.
+function _stop_spinner() {
+    [ $PROGRESS_ACTIVE -eq 1 ] || return 0
+    kill $SPINNER_PID 2>/dev/null || true
+    wait $SPINNER_PID 2>/dev/null || true
+    SPINNER_PID=0
+    exec 1>&3 2>&4
+    PROGRESS_ACTIVE=0
+}
+
+# Replay the captured progress log to the user's terminal, then remove it.
+# No-op when there is no logfile (verbose / non-interactive mode).
+function _replay_progress_log() {
+    [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ] || return 0
+    message red "--- Captured output (${PROGRESS_LABEL# }) ---"
+    cat "$PROGRESS_LOG"
+    message red "--- End of captured output ---"
+    rm -f "$PROGRESS_LOG"
+    PROGRESS_LOG=""
+}
+
+# Discard the captured progress log without replaying it (success path).
+function _clear_progress_log() {
+    [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ] || return 0
+    rm -f "$PROGRESS_LOG"
+    PROGRESS_LOG=""
+}
+
 function _done() {
     local rc=$?
     local had_spinner=$PROGRESS_ACTIVE
-    if [ $PROGRESS_ACTIVE -eq 1 ]; then
-      kill $SPINNER_PID 2>/dev/null || true
-      wait $SPINNER_PID 2>/dev/null || true
-      SPINNER_PID=0
-      exec 1>&3 2>&4
-      PROGRESS_ACTIVE=0
-    fi
+    _stop_spinner
 
     if [ $rc -ne 0 ]; then
       if [ $had_spinner -eq 1 ]; then
@@ -63,13 +86,7 @@ function _done() {
       else
         printf "\e[31m✘\e[39m\n"
       fi
-      if [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ]; then
-        message red "--- Captured output (${PROGRESS_LABEL# }) ---"
-        cat "$PROGRESS_LOG"
-        message red "--- End of captured output ---"
-        rm -f "$PROGRESS_LOG"
-        PROGRESS_LOG=""
-      fi
+      _replay_progress_log
       exit $rc
     fi
 
@@ -78,33 +95,17 @@ function _done() {
     else
       printf "\e[32m✔\e[39m\n"
     fi
-    if [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ]; then
-      rm -f "$PROGRESS_LOG"
-      PROGRESS_LOG=""
-    fi
+    _clear_progress_log
 }
 
-# EXIT trap: surfaces errors from `set -e` aborts mid-block. Restores file
-# descriptors, stops any running spinner, and dumps the captured log so the
-# user sees the actual command output that failed.
+# EXIT trap: surfaces errors from `set -e` aborts mid-block. Stops any running
+# spinner, restores file descriptors, and dumps the captured log so the user
+# sees the actual command output that failed.
 function _progress_exit_trap() {
-    local rc=$?
-    if [ $PROGRESS_ACTIVE -eq 1 ]; then
-      if [ $SPINNER_PID -ne 0 ]; then
-        kill $SPINNER_PID 2>/dev/null || true
-        wait $SPINNER_PID 2>/dev/null || true
-        SPINNER_PID=0
-      fi
-      exec 1>&3 2>&4
-      PROGRESS_ACTIVE=0
-      printf "\b\e[0m\e[31m✘\e[39m\n"
-      if [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ]; then
-        message red "--- Captured output (${PROGRESS_LABEL# }) ---"
-        cat "$PROGRESS_LOG"
-        message red "--- End of captured output ---"
-        rm -f "$PROGRESS_LOG"
-      fi
-    fi
+    [ $PROGRESS_ACTIVE -eq 1 ] || return 0
+    _stop_spinner
+    printf "\b\e[0m\e[31m✘\e[39m\n"
+    _replay_progress_log
 }
 trap _progress_exit_trap EXIT
 

--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
-# Global variable to store spinner PID
+# Verbose flag — set VERBOSE=1 (or pass -v/--verbose to `ddev install`) to
+# disable the spinner and stream all command output live.
+VERBOSE="${VERBOSE:-0}"
+
+# Internal state shared between _progress, _done and _progress_exit_trap.
 SPINNER_PID=0
+PROGRESS_ACTIVE=0
+PROGRESS_LOG=""
+PROGRESS_LABEL=""
 
 # Function to display a spinner at the current cursor position (simple colored style)
 function _spinner() {
     local chars="|/-\\"
     local delay=0.1
     local i=0
-    
+
     while true; do
         printf "\b\e[36m%c\e[0m" "${chars:$i:1}"
         ((i++))
@@ -20,37 +27,86 @@ function _spinner() {
 }
 
 function _progress() {
+    PROGRESS_LABEL="$1"
     printf "%s... " "$1"
-    # Check if we're in CI environment or non-interactive terminal
+    # Spinner mode only in interactive terminals outside CI and verbose runs.
     if [[ "$VERBOSE" -eq 0 ]] && [[ -z "$CI" ]] && [[ -z "$GITHUB_ACTIONS" ]] && [[ -z "$GITLAB_CI" ]] && [[ -z "$JENKINS_URL" ]] && [[ -t 1 ]]; then
-      # Print initial space for spinner
+      PROGRESS_LOG="$(mktemp)"
       printf " "
-      # Start spinner in background at current position
       _spinner &
       SPINNER_PID=$!
-      # Save current stdout/stderr
+      # Save stdout/stderr, capture command output to a logfile so we can
+      # replay it on failure instead of swallowing it into /dev/null.
       exec 3>&1 4>&2
-      exec >/dev/null 2>&1
+      exec >"$PROGRESS_LOG" 2>&1
+      PROGRESS_ACTIVE=1
     else
+      PROGRESS_LOG=""
       printf "\n"
     fi
 }
 
 function _done() {
-    # Stop spinner if it was started
-    if [ $SPINNER_PID -ne 0 ]; then
-      kill $SPINNER_PID 2>/dev/null
-      wait $SPINNER_PID 2>/dev/null
+    local rc=$?
+    local had_spinner=$PROGRESS_ACTIVE
+    if [ $PROGRESS_ACTIVE -eq 1 ]; then
+      kill $SPINNER_PID 2>/dev/null || true
+      wait $SPINNER_PID 2>/dev/null || true
       SPINNER_PID=0
-      # Restore stdout/stderr
       exec 1>&3 2>&4
-      # Clear any remaining color codes and replace with checkmark
+      PROGRESS_ACTIVE=0
+    fi
+
+    if [ $rc -ne 0 ]; then
+      if [ $had_spinner -eq 1 ]; then
+        printf "\b\e[0m\e[31m✘\e[39m\n"
+      else
+        printf "\e[31m✘\e[39m\n"
+      fi
+      if [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ]; then
+        message red "--- Captured output (${PROGRESS_LABEL# }) ---"
+        cat "$PROGRESS_LOG"
+        message red "--- End of captured output ---"
+        rm -f "$PROGRESS_LOG"
+        PROGRESS_LOG=""
+      fi
+      exit $rc
+    fi
+
+    if [ $had_spinner -eq 1 ]; then
       printf "\b\e[0m\e[32m✔\e[39m\n"
     else
-      # No spinner was running, just print checkmark
       printf "\e[32m✔\e[39m\n"
     fi
+    if [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ]; then
+      rm -f "$PROGRESS_LOG"
+      PROGRESS_LOG=""
+    fi
 }
+
+# EXIT trap: surfaces errors from `set -e` aborts mid-block. Restores file
+# descriptors, stops any running spinner, and dumps the captured log so the
+# user sees the actual command output that failed.
+function _progress_exit_trap() {
+    local rc=$?
+    if [ $PROGRESS_ACTIVE -eq 1 ]; then
+      if [ $SPINNER_PID -ne 0 ]; then
+        kill $SPINNER_PID 2>/dev/null || true
+        wait $SPINNER_PID 2>/dev/null || true
+        SPINNER_PID=0
+      fi
+      exec 1>&3 2>&4
+      PROGRESS_ACTIVE=0
+      printf "\b\e[0m\e[31m✘\e[39m\n"
+      if [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ]; then
+        message red "--- Captured output (${PROGRESS_LABEL# }) ---"
+        cat "$PROGRESS_LOG"
+        message red "--- End of captured output ---"
+        rm -f "$PROGRESS_LOG"
+      fi
+    fi
+}
+trap _progress_exit_trap EXIT
 
 
 # Function to get the lowest supported TYPO3 version from the environment variable TYPO3_VERSIONS

--- a/commands/web/.install-11
+++ b/commands/web/.install-11
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 ## #ddev-generated
 . .ddev/.setup/scripts/utils.sh

--- a/commands/web/.install-12
+++ b/commands/web/.install-12
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 . .ddev/.setup/scripts/utils.sh
 

--- a/commands/web/.install-13
+++ b/commands/web/.install-13
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 . .ddev/.setup/scripts/utils.sh
 

--- a/commands/web/.install-14
+++ b/commands/web/.install-14
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 . .ddev/.setup/scripts/utils.sh
 

--- a/commands/web/install
+++ b/commands/web/install
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 
 ## #ddev-generated
-## Description: Install TYPO3 instances.
-## Usage: install
-## Example: "ddev install" or "ddev install 12" or "ddev install all"
+## Description: Install TYPO3 instances. Pass -v/--verbose to stream all command output.
+## Usage: install [version|all] [-v|--verbose]
+## Example: "ddev install" or "ddev install 12" or "ddev install all" or "ddev install 14 -v"
 ## MutagenSync: true
 
-TYPO3=${1}
+TYPO3=""
+for arg in "$@"; do
+    case "$arg" in
+        -v|--verbose) export VERBOSE=1 ;;
+        *) [ -z "$TYPO3" ] && TYPO3="$arg" ;;
+    esac
+done
 
 . .ddev/.setup/scripts/utils.sh
 


### PR DESCRIPTION
## Summary

Today the `_progress`/`_done` spinner pattern in `.setup/scripts/utils.sh` redirects all command output to `/dev/null`. When a step inside the spinner block fails (e.g. `composer req`, `mysql -e "CREATE DATABASE …"`, `$TYPO3_BIN install:setup`), the user sees a green ✔ and the install silently moves on with broken state — there is no way to see what actually happened. The `$VERBOSE` env var was checked but never wired to anything reachable from the user.

This PR fixes both layers:

- **Option 2 — verbose flag**: `ddev install [version|all] [-v|--verbose]` now toggles `VERBOSE=1`, which disables the spinner and streams output live (the existing `$VERBOSE` gate already supported this — only the wiring was missing).
- **Option 3 — error surfacing**: in spinner mode the captured output goes to a `mktemp` logfile instead of `/dev/null`. On failure, `_done` and an `EXIT` trap restore the file descriptors, print a red ✘, and dump the captured log so the user sees the actual error. `set -eo pipefail` in the four `.install-XX` entrypoints ensures mid-block failures are no longer silently swallowed.

## Changes

- `commands/web/install` — argument parser accepts `-v`/`--verbose` in any position, exports `VERBOSE=1` for the dispatched `.install-XX` script. Docstring updated with the new usage.
- `.setup/scripts/utils.sh`
  - `VERBOSE` defaults to `0` instead of relying on unset-as-empty.
  - `_progress` redirects spinner-mode output to a per-call `mktemp` logfile and tracks `PROGRESS_ACTIVE`, `PROGRESS_LOG`, `PROGRESS_LABEL`.
  - `_done` reads `$?`, prints ✘ and replays the log on non-zero (then `exit $rc`); ✔ otherwise.
  - New `_progress_exit_trap` registered as `EXIT` trap — restores FDs, kills any spinner, and dumps the log when `set -e` aborts the script mid-block.
  - `kill`/`wait` calls hardened with `|| true` so they don't trip `set -e` themselves.
- `commands/web/.install-{11,12,13,14}` — `set -eo pipefail` so a failed command anywhere in the install pipeline halts immediately and surfaces via the trap.

## Behavior matrix

| Invocation | Spinner | Output stream | On failure |
|---|---|---|---|
| `ddev install 14` (TTY, success) | yes | hidden | n/a |
| `ddev install 14` (TTY, failure) | yes → ✘ | replayed from logfile | red banner, exit non-zero |
| `ddev install 14 -v` | no | live | live, exit non-zero |
| `ddev install` in CI (`$CI` set) | no | live | live, exit non-zero |

## Test plan

- [ ] `ddev install 14` on a green path — spinner + ✔, no log spam
- [ ] `ddev install 14 -v` — no spinner, full output
- [ ] Force a failure (e.g. break a composer constraint in `.install-14`) → red ✘ + dumped output
- [ ] Same failure with `-v` → live output, non-zero exit
- [ ] `ddev install all -v` and `ddev install -v 12` both honor the flag
- [ ] `ddev install` (no args) still picks the lowest supported version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added verbose mode flag (`-v/--verbose`) to installation command for live output display.

* **Bug Fixes**
  * Enhanced progress UI with improved spinner control and output capture on failures.
  * Strengthened error handling in installation scripts to detect and terminate on command failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->