### PR TITLE
refactor: extract progress helpers from _done and exit trap

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -46,16 +46,39 @@ function _progress() {
     fi
 }
 
+# Stop the spinner (if running) and restore the original stdout/stderr file
+# descriptors. Idempotent — safe to call when no progress region is active.
+function _stop_spinner() {
+    [ $PROGRESS_ACTIVE -eq 1 ] || return 0
+    kill $SPINNER_PID 2>/dev/null || true
+    wait $SPINNER_PID 2>/dev/null || true
+    SPINNER_PID=0
+    exec 1>&3 2>&4
+    PROGRESS_ACTIVE=0
+}
+
+# Replay the captured progress log to the user's terminal, then remove it.
+# No-op when there is no logfile (verbose / non-interactive mode).
+function _replay_progress_log() {
+    [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ] || return 0
+    message red "--- Captured output (${PROGRESS_LABEL# }) ---"
+    cat "$PROGRESS_LOG"
+    message red "--- End of captured output ---"
+    rm -f "$PROGRESS_LOG"
+    PROGRESS_LOG=""
+}
+
+# Discard the captured progress log without replaying it (success path).
+function _clear_progress_log() {
+    [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ] || return 0
+    rm -f "$PROGRESS_LOG"
+    PROGRESS_LOG=""
+}
+
 function _done() {
     local rc=$?
     local had_spinner=$PROGRESS_ACTIVE
-    if [ $PROGRESS_ACTIVE -eq 1 ]; then
-      kill $SPINNER_PID 2>/dev/null || true
-      wait $SPINNER_PID 2>/dev/null || true
-      SPINNER_PID=0
-      exec 1>&3 2>&4
-      PROGRESS_ACTIVE=0
-    fi
+    _stop_spinner
 
     if [ $rc -ne 0 ]; then
       if [ $had_spinner -eq 1 ]; then
@@ -63,13 +86,7 @@ function _done() {
       else
         printf "\e[31m✘\e[39m\n"
       fi
-      if [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ]; then
-        message red "--- Captured output (${PROGRESS_LABEL# }) ---"
-        cat "$PROGRESS_LOG"
-        message red "--- End of captured output ---"
-        rm -f "$PROGRESS_LOG"
-        PROGRESS_LOG=""
-      fi
+      _replay_progress_log
       exit $rc
     fi
 
@@ -78,33 +95,17 @@ function _done() {
     else
       printf "\e[32m✔\e[39m\n"
     fi
-    if [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ]; then
-      rm -f "$PROGRESS_LOG"
-      PROGRESS_LOG=""
-    fi
+    _clear_progress_log
 }
 
-# EXIT trap: surfaces errors from `set -e` aborts mid-block. Restores file
-# descriptors, stops any running spinner, and dumps the captured log so the
-# user sees the actual command output that failed.
+# EXIT trap: surfaces errors from `set -e` aborts mid-block. Stops any running
+# spinner, restores file descriptors, and dumps the captured log so the user
+# sees the actual command output that failed.
 function _progress_exit_trap() {
-    local rc=$?
-    if [ $PROGRESS_ACTIVE -eq 1 ]; then
-      if [ $SPINNER_PID -ne 0 ]; then
-        kill $SPINNER_PID 2>/dev/null || true
-        wait $SPINNER_PID 2>/dev/null || true
-        SPINNER_PID=0
-      fi
-      exec 1>&3 2>&4
-      PROGRESS_ACTIVE=0
-      printf "\b\e[0m\e[31m✘\e[39m\n"
-      if [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ]; then
-        message red "--- Captured output (${PROGRESS_LABEL# }) ---"
-        cat "$PROGRESS_LOG"
-        message red "--- End of captured output ---"
-        rm -f "$PROGRESS_LOG"
-      fi
-    fi
+    [ $PROGRESS_ACTIVE -eq 1 ] || return 0
+    _stop_spinner
+    printf "\b\e[0m\e[31m✘\e[39m\n"
+    _replay_progress_log
 }
 trap _progress_exit_trap EXIT
 


### PR DESCRIPTION
## Summary

Pure DRY refactor on top of #12. Extracts three small helpers from `_done` and the EXIT trap so future tweaks (different banner format, log rotation, color changes) only have to land in one place.

No behavior change — the success path, failure path, and `set -e` mid-block path all produce identical output before and after.

## Why

After #12 landed, `_done` and `_progress_exit_trap` duplicated two cleanup blocks byte-for-byte:

- "Stop spinner + restore FDs" (5 lines)
- "Replay logfile and remove it" (6 lines)

Strict Rule of Three says "wait, don't extract yet" at 2x duplication, but the blocks are exact copies and any change to either has to be mirrored. Extracting now is a net win.

## Changes

- `.setup/scripts/utils.sh`
  - New `_stop_spinner()` — guarded, idempotent spinner teardown + FD restore.
  - New `_replay_progress_log()` — banner + `cat` + `rm` for the failure path.
  - New `_clear_progress_log()` — bare cleanup for the success path.
  - `_done` and `_progress_exit_trap` collapse to call the helpers.

## Test plan

- [x] `bash -n .setup/scripts/utils.sh` clean
- [x] Success + failure smoke test (`VERBOSE=1`) produces ✔ / ✘ and exit code 1 as expected
- [x] EXIT trap is harmless on clean exits
- [ ] Manual: `ddev install 14` (success), `ddev install 14` with a forced break (failure replays log)

## Stack

This PR targets `feat/verbose-and-error-surfacing` (#12). Once that merges, GitHub will retarget this PR to `main` automatically.
