### PR TITLE
[TASK] Make message() function available in child bash processes

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -560,3 +560,4 @@ message() {
             ;;
     esac
 }
+export -f message


### PR DESCRIPTION
Make the colored-output helper available to external scripts spawned as child processes, so they can use it without additional sourcing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved shell script configuration to enhance subprocess compatibility and ensure proper function availability across all execution contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konradmichalik/ddev-typo3-multi-version-extension/pull/14)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->