### PR TITLE
[BUGFIX] Set explicit trusted host pattern per TYPO3 instance

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -332,7 +332,7 @@ function setup_typo3() {
     $TYPO3_BIN configuration:set 'FE/debug' 1
     $TYPO3_BIN configuration:set 'SYS/devIPmask' '*'
     $TYPO3_BIN configuration:set 'SYS/displayErrors' 1
-    $TYPO3_BIN configuration:set 'SYS/trustedHostsPattern' '.*.*'
+    $TYPO3_BIN configuration:set 'SYS/trustedHostsPattern' "$VERSION.$EXTENSION_NAME.ddev.site"
     $TYPO3_BIN configuration:set 'MAIL/transport' 'smtp'
     $TYPO3_BIN configuration:set 'MAIL/transport_smtp_server' 'localhost:1025'
     $TYPO3_BIN configuration:set 'GFX/processor' 'ImageMagick'


### PR DESCRIPTION
## The Issue

The wildcard pattern caused TYPO3 to accept any host for backend authentication, which resulted in session conflicts when logging into multiple instances simultaneously. Since all instances shared the same wildcard, a login on instance B would invalidate the session of instance A.

## How This PR Solves The Issue

Replace the wildcard trusted host pattern `.*.*` with the instance-specific hostname `$VERSION.$EXTENSION_NAME.ddev.site`.

By using the exact hostname of each instance, sessions are properly isolated and concurrent backend logins across multiple instances work as expected.