### PR TITLE
fix: use generic vendor name in composer init

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -314,7 +314,7 @@ function create_symlinks_additional_extensions() {
 # configures the TYPO3 web directory, sets up the repository for packages,
 # and allows necessary Composer plugins.
 function setup_composer() {
-    composer init --name="xima/typo3-$VERSION" --description="TYPO3 $VERSION" --no-interaction --working-dir "$BASE_PATH"
+    composer init --name="test/typo3-$VERSION" --description="TYPO3 $VERSION" --no-interaction --working-dir "$BASE_PATH"
     composer config extra.typo3/cms.web-dir public --working-dir "$BASE_PATH"
     composer config repositories.packages path 'packages/*' --working-dir "$BASE_PATH"
     composer config --no-interaction allow-plugins.typo3/cms-composer-installers true --working-dir "$BASE_PATH"


### PR DESCRIPTION
## Summary

- Replace hardcoded `xima/typo3-<version>` vendor name in the auto-generated `composer.json` with a generic `test/typo3-<version>` placeholder

## Changes

- `.setup/scripts/utils.sh` — `setup_composer()` now initializes the per-version Composer project under a neutral `test/` vendor instead of a project-specific one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package name configuration in the setup script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->