### PR TITLE
fix: run post-install sed under LC_ALL=C to avoid illegal byte sequence

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -32,6 +32,7 @@ ddev_version_constraint: '>= v1.24.3'
 post_install_actions:
   - |
     #ddev-description:Replace package name
+    export LC_ALL=C LANG=C
     if [ -f ${DDEV_APPROOT}/composer.json ]; then
       composer_name=$(jq -r '.name' ${DDEV_APPROOT}/composer.json)
       if [ ! -z "$composer_name" ]; then
@@ -46,6 +47,7 @@ post_install_actions:
 
   - |
     #ddev-description:Replace extension key and name
+    export LC_ALL=C LANG=C
     extension_name="${DDEV_PROJECT}"
     extension_key=$(echo "$extension_name" | tr '-' '_')
     if [ -z "$extension_name" ]; then


### PR DESCRIPTION
## The Issue

On macOS (BSD `sed`) with a non-UTF-8 shell locale, the post-install actions abort with `sed: RE error: illegal byte sequence`, so `ddev add-on get` / `ddev restart` fail. Both "Replace package name" and "Replace extension key and name" run `sed` over every file in `.ddev/`, and any non-ASCII byte triggers the error.

## How This PR Solves The Issue

Adds `export LC_ALL=C` to both sed-running post-install actions. Each `post_install_action` runs in its own shell, so the export is repeated per action rather than set once. The substituted strings are ASCII, so byte-mode `sed` leaves multibyte content untouched and output is unchanged on already-working hosts.

## Manual Testing Instructions

1. On macOS, force a non-UTF-8 locale: `unset LC_ALL; export LANG=`
2. In a project with `apache-fpm` and a valid `composer.json`, run:
   `ddev add-on get <this-fork/branch> && ddev restart`
3. On `main` the install fails with `illegal byte sequence`; with this PR it completes.
4. Re-check on Linux and on a UTF-8 macOS locale — both still succeed.

## Automated Testing Overview

No automated tests added — the add-on has no install-time test harness for locale variants, and the change is a one-line environment guard per action. Optionally, a CI job running the install under `LANG=` / `LC_ALL=C` could cover this.

## Release/Deployment Notes

No breaking changes and no deployment steps. `LC_ALL=C` only affects byte interpretation during the substitutions (all ASCII), so behaviour is identical on hosts where install already worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer reliability by standardizing locale settings during setup, reducing the chance of unexpected text-processing issues on different systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->