### PR TITLE
Add classic (non-Composer) mode to install command

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -195,14 +195,24 @@ function check_typo3_version() {
 #   pre_setup <TYPO3_VERSION>
 function pre_setup() {
   export VERSION=$1
-  message magenta "Install TYPO3 $VERSION"
+  export MODE="${MODE:-composer}"
+  export BASE_PATH="/var/www/html/.Build/$VERSION"
+
+  message magenta "Install TYPO3 $VERSION (${MODE})"
   _progress " ├─ Prepare environment"
-    export BASE_PATH="/var/www/html/.Build/$VERSION"
     intro_typo3
-    message blue "Pre Setup for TYPO3 $VERSION"
+    message blue "Pre Setup for TYPO3 $VERSION (${MODE})"
   _done
-  install_start
-  install_composer_packages
+
+  # Classic (non-Composer) installs rebuild the same version slot without a
+  # Composer project, so they follow a dedicated preparation path. The Composer
+  # path stays byte-for-byte identical to before.
+  if [ "$MODE" = "classic" ]; then
+    classic_install_start
+  else
+    install_start
+    install_composer_packages
+  fi
 }
 
 # Function to perform post-setup tasks for TYPO3 installation.
@@ -210,6 +220,16 @@ function pre_setup() {
 # and calls the appropriate post-setup function based on the TYPO3 version.
 # After that, it imports data and updates TYPO3.
 function post_setup() {
+  # Classic installs finalise through a dedicated path (core CLI binary,
+  # explicit extension activation, docroot-relative config). The Composer path
+  # below stays unchanged.
+  if [ "${MODE:-composer}" = "classic" ]; then
+    classic_post_setup
+    printf " └─ \033[33mTYPO3 %s (classic) setup completed!\033[0m Open: https://%s.%s.ddev.site\n" \
+           "$VERSION" "$VERSION" "$EXTENSION_NAME"
+    return
+  fi
+
   prepare_acceptance_testing
 
   cd "$BASE_PATH" || { message red "Failed to change to $BASE_PATH"; return 1; }
@@ -237,6 +257,64 @@ function post_setup() {
     update_typo3
   _done
   printf " └─ \033[33mTYPO3 $VERSION setup completed!\033[0m Open in your browser: https://$VERSION.${EXTENSION_NAME}.ddev.site\n"
+}
+
+# Function to perform post-setup tasks for a classic (non-Composer) install.
+# It runs the env-driven TYPO3 setup against the core CLI binary, activates the
+# extensions the classic way (classic mode does NOT auto-activate them),
+# applies the development configuration, imports the fixtures and updates the
+# database schema. Import and configuration helpers are reused unchanged — they
+# operate on $TYPO3_BIN and the public/ paths within the same version slot.
+function classic_post_setup() {
+  cd "$BASE_PATH/public" || { message red "Failed to change to $BASE_PATH/public"; return 1; }
+  mysql -h db -u root -proot -e "CREATE DATABASE IF NOT EXISTS $DATABASE;"
+
+  _progress " ├─ Setup TYPO3 (classic)"
+    # env-driven, reuses the existing TYPO3_DB_* / TYPO3_SETUP_* variables.
+    # In classic mode this writes to typo3conf/system/settings.php.
+    $TYPO3_BIN setup -n \
+        --dbname="$DATABASE" \
+        --password="$TYPO3_DB_PASSWORD" \
+        --admin-user-password="$TYPO3_SETUP_ADMIN_PASSWORD" \
+        --create-site="https://${VERSION}.${EXTENSION_NAME}.ddev.site"
+  _done
+
+  _progress " ├─ Activate extensions (classic)"
+    # Classic mode does NOT auto-activate extensions found in typo3conf/ext
+    # (unlike Composer mode since v11). Activation is PackageStates-based and
+    # must be done explicitly. The core CLI ships hidden commands
+    # 'extension:activate' / 'extension:deactivate' for exactly this case
+    # (verified for v11/v12 — VERIFY they still exist in v13/v14; if not,
+    # fall back to writing the PackageStates entry programmatically).
+    $TYPO3_BIN extension:activate "$EXTENSION_KEY"
+    for dir in /var/www/html/Tests/Acceptance/Fixtures/packages/*/; do
+        [ -d "$dir" ] || continue
+        $TYPO3_BIN extension:activate "$(basename "$dir")" || true
+    done
+    # impexp is an optional system extension and needed for the XML fixture
+    # import below — activate it only if XML fixtures exist.
+    if ls /var/www/html/Tests/Acceptance/Fixtures/*.xml >/dev/null 2>&1; then
+        $TYPO3_BIN extension:activate impexp || true
+    fi
+    # extension:setup performs the post-activation steps (db schema, defaults).
+    $TYPO3_BIN extension:setup
+  _done
+
+  _progress " ├─ Configure TYPO3 (classic)"
+    $TYPO3_BIN configuration:set 'SYS/trustedHostsPattern' "${VERSION}.${EXTENSION_NAME}.ddev.site"
+    $TYPO3_BIN configuration:set 'BE/debug' 1
+    $TYPO3_BIN configuration:set 'FE/debug' 1
+    $TYPO3_BIN configuration:set 'SYS/devIPmask' '*'
+    $TYPO3_BIN configuration:set 'SYS/displayErrors' 1
+  _done
+
+  _progress " ├─ Import data"
+    import_xml_data; import_sql_data; import_site_configs; run_fixture_scripts
+  _done
+  _progress " ├─ Update TYPO3"
+    $TYPO3_BIN database:updateschema
+    $TYPO3_BIN cache:flush
+  _done
 }
 
 # Function to display an introductory message for the TYPO3 version.
@@ -275,6 +353,9 @@ function setup_environment() {
     rm -rf "$BASE_PATH"
     mkdir -p "$BASE_PATH/packages/$EXTENSION_KEY"
     chmod 775 -R $BASE_PATH
+    # Mode marker read by the exec wrappers (ddev <v> …) to pick the right
+    # binary and working directory. Missing marker falls back to "composer".
+    echo "composer" > "$BASE_PATH/.install-mode"
     export DATABASE="database_$VERSION"
     if [ "$VERSION" == "11" ]; then
         export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3cms"
@@ -286,17 +367,25 @@ function setup_environment() {
 
 # Function to create symlinks for the main extension.
 # It iterates over the items in the current directory, excluding certain directories and files,
-# and creates symbolic links for the remaining items in the specified base path.
+# and creates symbolic links for the remaining items in the given target directory.
+# The target directory defaults to the Composer package path, so callers that
+# omit the argument keep the previous behaviour; the classic path passes the
+# TER-style typo3conf/ext/<key> directory instead.
+#
+# Arguments:
+#   $1 - Target directory (default: $BASE_PATH/packages/$EXTENSION_KEY).
 function create_symlinks_main_extension() {
+    local target="${1:-$BASE_PATH/packages/$EXTENSION_KEY}"
+    mkdir -p "$target"
     local exclusions=(".*" "Documentation" "Documentation-GENERATED-temp" "var")
     for item in ./*; do
-        local base_name=$(basename "$item")
+        local base_name; base_name=$(basename "$item")
         for exclusion in "${exclusions[@]}"; do
             if [[ $base_name == "$exclusion" ]]; then
                 continue 2
             fi
         done
-        ln -sr "$item" "$BASE_PATH/packages/$EXTENSION_KEY/$base_name"
+        ln -sr "$item" "$target/$base_name"
     done
 }
 
@@ -306,6 +395,81 @@ function create_symlinks_main_extension() {
 function create_symlinks_additional_extensions() {
     for dir in Tests/Acceptance/Fixtures/packages/*/; do
         ln -sr "$dir" "$BASE_PATH/packages/$(basename "$dir")"
+    done
+}
+
+# Function to start a classic (non-Composer) installation for the current
+# version. It rebuilds the same version slot from scratch: it prepares the
+# environment, downloads the matching TYPO3 sources from get.typo3.org and
+# wires up the classic docroot symlinks. There is deliberately no Composer
+# step here — see classic_create_symlinks for why.
+function classic_install_start() {
+    rm -rf "$BASE_PATH"
+    _progress " ├─ Setup environment"
+      classic_setup_environment
+    _done
+    _progress " ├─ Download TYPO3 $VERSION sources"
+      classic_download_sources
+    _done
+    _progress " ├─ Create symlinks"
+      classic_create_symlinks
+    _done
+}
+
+# Function to set up the environment for a classic TYPO3 installation.
+# It creates the classic docroot layout (typo3conf/ext, fileadmin, typo3temp),
+# writes the "classic" mode marker, exports the database name and the TYPO3
+# binary (the core CLI shipped in the sources, NOT vendor/bin), and drops any
+# existing database for the version.
+function classic_setup_environment() {
+    mkdir -p "$BASE_PATH/public/typo3conf/ext"
+    mkdir -p "$BASE_PATH/public/fileadmin" "$BASE_PATH/public/typo3temp"
+    chmod 775 -R "$BASE_PATH"
+    echo "classic" > "$BASE_PATH/.install-mode"
+    export DATABASE="database_$VERSION"
+    export TYPO3_BIN="$BASE_PATH/public/typo3/sysext/core/bin/typo3"   # core binary, NOT vendor/bin
+    mysql -uroot -proot -e "DROP DATABASE IF EXISTS $DATABASE"
+}
+
+# Function to download the TYPO3 sources for the current major version.
+# get.typo3.org/<major> redirects to the current source tarball of that major,
+# which is unpacked into a version-specific source directory.
+function classic_download_sources() {
+    local src_dir="$BASE_PATH/typo3_src-$VERSION"
+    mkdir -p "$src_dir"
+    # get.typo3.org/<major> redirects to the current source tarball of that major.
+    # -f is essential: without it, an HTML error page would be piped into tar.
+    curl -fsSL "https://get.typo3.org/$VERSION" | tar xz --strip-components=1 -C "$src_dir"
+}
+
+# Function to create the symlinks for a classic docroot.
+# It wires up the classic source symlink trio (typo3_src, typo3, index.php),
+# copies the shipped _.htaccess into the docroot, and symlinks the main
+# extension plus the fixture packages into typo3conf/ext/<key>.
+#
+# No Composer autoloader is used on purpose: the extension is linked like a TER
+# install so TYPO3 has to resolve its classes from the `autoload` key in
+# ext_emconf.php (v12/v13) resp. from the extension's composer.json (v14) —
+# which is exactly the fidelity this mode exists to test.
+function classic_create_symlinks() {
+    ( cd "$BASE_PATH/public"
+      ln -sf "../typo3_src-$VERSION" typo3_src
+      ln -sf typo3_src/typo3         typo3
+      ln -sf typo3_src/index.php     index.php )
+    # Apache rewrites for slug-based frontend URLs: the source package ships a
+    # ready-made _.htaccess in its root — copy it into the docroot.
+    if [ -f "$BASE_PATH/typo3_src-$VERSION/_.htaccess" ]; then
+        cp "$BASE_PATH/typo3_src-$VERSION/_.htaccess" "$BASE_PATH/public/.htaccess"
+    fi
+    # Main extension → typo3conf/ext/<underscored key>, faithful to a TER layout.
+    # No composer autoloader: TYPO3 must resolve classes from ext_emconf.php
+    # (v12/v13) resp. the extension's composer.json (v14).
+    ( cd /var/www/html
+      create_symlinks_main_extension "$BASE_PATH/public/typo3conf/ext/$EXTENSION_KEY" )
+    # Sitepackage + additional fixture packages, same target dir.
+    for dir in /var/www/html/Tests/Acceptance/Fixtures/packages/*/; do
+        [ -d "$dir" ] || continue
+        ln -sr "$dir" "$BASE_PATH/public/typo3conf/ext/$(basename "$dir")"
     done
 }
 
@@ -439,7 +603,13 @@ function import_site_configs() {
         return
     fi
 
-    TARGET_BASE="/var/www/html/.Build/$VERSION/config/sites"
+    # Classic mode reads site configs from public/typo3conf/sites/, whereas the
+    # Composer mode uses config/sites/. Pick the target accordingly.
+    if [ "${MODE:-composer}" = "classic" ]; then
+        TARGET_BASE="/var/www/html/.Build/$VERSION/public/typo3conf/sites"
+    else
+        TARGET_BASE="/var/www/html/.Build/$VERSION/config/sites"
+    fi
 
     mkdir -p "$TARGET_BASE"
 

--- a/.setup/templates/index.php
+++ b/.setup/templates/index.php
@@ -46,7 +46,11 @@ if (file_exists($composerJsonPath)) {
     foreach ($supportedVersions as $version) {
         $directoryPath = '/var/www/html/.Build/' . $version;
         if (is_dir($directoryPath)) {
-            echo "<article class='flex'><kbd>{$version}</kbd><div><strong>Frontend</strong><br/><strong>Backend</strong></div><div><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site'>https://{$version}.{$extensionKey}.ddev.site</a><br/><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site/typo3/?u={$typo3AdminUser}&p={$typo3AdminPassword}'>https://{$version}.{$extensionKey}.ddev.site/typo3</a></div></article>";
+            // Read the install-mode marker so the intro page shows whether a
+            // version slot was built in composer (default) or classic mode.
+            $modeFile = $directoryPath . '/.install-mode';
+            $mode = is_file($modeFile) ? trim(file_get_contents($modeFile)) : 'composer';
+            echo "<article class='flex'><kbd>{$version}</kbd><div><small>{$mode}</small></div><div><strong>Frontend</strong><br/><strong>Backend</strong></div><div><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site'>https://{$version}.{$extensionKey}.ddev.site</a><br/><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site/typo3/?u={$typo3AdminUser}&p={$typo3AdminPassword}'>https://{$version}.{$extensionKey}.ddev.site/typo3</a></div></article>";
         } else {
             echo "<article>Version {$version} is not installed. Run <code>ddev install {$version}</code> to install.</article>";
         }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ ddev install all
 ddev install 12
 ```
 
+You can also rebuild a single version as a Composer-free (TER-style) instance with
+`ddev install 13 --classic` — see [🧩 Classic mode](#-classic-mode-non-composer).
+
 ![Screencast](./images/screencast.gif)
 
 For a detailed console output, use the following command:
@@ -86,6 +89,47 @@ During installation, fixture data from `Tests/Acceptance/Fixtures/` is automatic
 | SQL | `Tests/Acceptance/Fixtures/*.sql` | Raw SQL files, imported directly into the database |
 | Site config | `Tests/Acceptance/Fixtures/sites/<site-name>/` | Site configuration directories copied to `config/sites/`. Use `VERSION_PLACEHOLDER` in `config.yaml` to insert the TYPO3 version automatically. |
 | Shell scripts | `Tests/Acceptance/Fixtures/*.sh` | Executed during setup (failures are logged but don't abort the installation) |
+
+## 🧩 Classic mode (non-Composer)
+
+Most extensions on the TER are installed in **classic mode** (non-Composer), where TYPO3
+resolves classes from the `autoload` key in `ext_emconf.php` instead of Composer's PSR-4
+autoloader. Bugs that only surface there — a missing or drifted `ext_emconf.php` autoload
+key, an extension key mismatch, or a runtime dependency that only exists because Composer
+happened to pull it in — stay invisible in the default Composer-mode instances.
+
+Append `--classic` to an install to (re)build that version as a Composer-free instance:
+
+    ddev install 13 --classic
+
+This **replaces the version 13 slot in place**: TYPO3 sources are downloaded from
+`get.typo3.org` (no `composer install`), your extension is symlinked into
+`typo3conf/ext/<extension_key>` and activated the classic way — exactly like on the TER.
+On TYPO3 v12/v13, class loading is driven by the `autoload` key in `ext_emconf.php`;
+on TYPO3 v14, classic mode requires a `composer.json` in the extension instead. The
+instance keeps the same hostname:
+
+    https://13.<extension-name>.ddev.site
+
+The regular commands detect the mode automatically:
+
+    ddev 13 typo3 cache:flush
+    ddev launch 13
+
+To switch back to a Composer instance, re-run the install without the flag:
+
+    ddev install 13
+
+**Notes**
+
+- A version slot is either Composer or classic at a time, not both — rebuild to switch.
+  Different versions can still run in different modes side by side (e.g. Composer 13 and
+  classic 14).
+- Classic mode is **per version** and is not part of `ddev install all`.
+- Only TYPO3 v12+ is supported in classic mode.
+- On TYPO3 v14, classic mode only recognises extensions that ship a `composer.json` —
+  make sure your extension provides one before testing v14 in classic mode.
+- `composer` commands (`ddev 13 composer ...`) are unavailable while a slot is in classic mode.
 
 ## 📊 Usage
 

--- a/commands/web/12
+++ b/commands/web/12
@@ -8,16 +8,34 @@
 
 command=$@
 version=12
-
-if [[ $command == typo3* ]]; then
-    command="/usr/bin/php vendor/bin/${command}"
-fi
-
 TYPO3_PATH=".Build/${version}"
-if [ -d "$TYPO3_PATH" ]; then
-    message magenta "[TYPO3 v${version}] ${command}"
-    cd $TYPO3_PATH
-    $command
-else
-    message red "TYPO3 binary not found for version ${version}"
+
+if [ ! -d "$TYPO3_PATH" ]; then
+    message red "TYPO3 instance not found for version ${version}"
+    exit 1
 fi
+
+# Read the mode marker written at install time to pick the right binary and
+# working directory. A missing marker means a Composer instance.
+mode=$(cat "${TYPO3_PATH}/.install-mode" 2>/dev/null || echo composer)
+
+if [ "$mode" = "classic" ]; then
+    exec_dir="${TYPO3_PATH}/public"
+    if [[ $command == composer* ]]; then
+        message red "Version ${version} is installed in classic (non-Composer) mode."
+        message yellow "Run 'ddev install ${version}' to switch it back to a Composer instance."
+        exit 1
+    fi
+    if [[ $command == typo3* ]]; then
+        command="/usr/bin/php typo3/sysext/core/bin/${command}"
+    fi
+else
+    exec_dir="${TYPO3_PATH}"
+    if [[ $command == typo3* ]]; then
+        command="/usr/bin/php vendor/bin/${command}"
+    fi
+fi
+
+message magenta "[TYPO3 v${version} (${mode})] ${command}"
+cd "$exec_dir"
+$command

--- a/commands/web/13
+++ b/commands/web/13
@@ -8,16 +8,34 @@
 
 command=$@
 version=13
-
-if [[ $command == typo3* ]]; then
-    command="/usr/bin/php vendor/bin/${command}"
-fi
-
 TYPO3_PATH=".Build/${version}"
-if [ -d "$TYPO3_PATH" ]; then
-    message magenta "[TYPO3 v${version}] ${command}"
-    cd $TYPO3_PATH
-    $command
-else
-    message red "TYPO3 binary not found for version ${version}"
+
+if [ ! -d "$TYPO3_PATH" ]; then
+    message red "TYPO3 instance not found for version ${version}"
+    exit 1
 fi
+
+# Read the mode marker written at install time to pick the right binary and
+# working directory. A missing marker means a Composer instance.
+mode=$(cat "${TYPO3_PATH}/.install-mode" 2>/dev/null || echo composer)
+
+if [ "$mode" = "classic" ]; then
+    exec_dir="${TYPO3_PATH}/public"
+    if [[ $command == composer* ]]; then
+        message red "Version ${version} is installed in classic (non-Composer) mode."
+        message yellow "Run 'ddev install ${version}' to switch it back to a Composer instance."
+        exit 1
+    fi
+    if [[ $command == typo3* ]]; then
+        command="/usr/bin/php typo3/sysext/core/bin/${command}"
+    fi
+else
+    exec_dir="${TYPO3_PATH}"
+    if [[ $command == typo3* ]]; then
+        command="/usr/bin/php vendor/bin/${command}"
+    fi
+fi
+
+message magenta "[TYPO3 v${version} (${mode})] ${command}"
+cd "$exec_dir"
+$command

--- a/commands/web/14
+++ b/commands/web/14
@@ -8,16 +8,34 @@
 
 command=$@
 version=14
-
-if [[ $command == typo3* ]]; then
-    command="/usr/bin/php vendor/bin/${command}"
-fi
-
 TYPO3_PATH=".Build/${version}"
-if [ -d "$TYPO3_PATH" ]; then
-    message magenta "[TYPO3 v${version}] ${command}"
-    cd $TYPO3_PATH
-    $command
-else
-    message red "TYPO3 binary not found for version ${version}"
+
+if [ ! -d "$TYPO3_PATH" ]; then
+    message red "TYPO3 instance not found for version ${version}"
+    exit 1
 fi
+
+# Read the mode marker written at install time to pick the right binary and
+# working directory. A missing marker means a Composer instance.
+mode=$(cat "${TYPO3_PATH}/.install-mode" 2>/dev/null || echo composer)
+
+if [ "$mode" = "classic" ]; then
+    exec_dir="${TYPO3_PATH}/public"
+    if [[ $command == composer* ]]; then
+        message red "Version ${version} is installed in classic (non-Composer) mode."
+        message yellow "Run 'ddev install ${version}' to switch it back to a Composer instance."
+        exit 1
+    fi
+    if [[ $command == typo3* ]]; then
+        command="/usr/bin/php typo3/sysext/core/bin/${command}"
+    fi
+else
+    exec_dir="${TYPO3_PATH}"
+    if [[ $command == typo3* ]]; then
+        command="/usr/bin/php vendor/bin/${command}"
+    fi
+fi
+
+message magenta "[TYPO3 v${version} (${mode})] ${command}"
+cd "$exec_dir"
+$command

--- a/commands/web/all
+++ b/commands/web/all
@@ -11,7 +11,28 @@ mapfile -t versions < <(get_supported_typo3_versions)
 
 for version in "${versions[@]}"; do
     TYPO3_PATH="/var/www/html/.Build/${version}"
-    if [ -d "$TYPO3_PATH" ]; then
+    if [ ! -d "$TYPO3_PATH" ]; then
+        message red "TYPO3 instance not found for version ${version}"
+        continue
+    fi
+
+    # Per-slot mode detection: classic instances live in public/ and use the
+    # core CLI binary, Composer instances use vendor/bin. Reset tempCommand each
+    # iteration so a non-typo3 command does not carry over from a previous slot.
+    mode=$(cat "${TYPO3_PATH}/.install-mode" 2>/dev/null || echo composer)
+    tempCommand="$command"
+    exec_dir="$TYPO3_PATH"
+
+    if [ "$mode" = "classic" ]; then
+        exec_dir="${TYPO3_PATH}/public"
+        if [[ $command == composer* ]]; then
+            message yellow "[TYPO3 v${version} (classic)] skipping 'composer' (non-Composer instance)"
+            continue
+        fi
+        if [[ $command == typo3* ]]; then
+            tempCommand="/usr/bin/php typo3/sysext/core/bin/${command}"
+        fi
+    else
         if [[ $command == typo3* ]]; then
             if [[ $version == 11 ]]; then
                 tempCommand="/usr/bin/php vendor/bin/typo3cms${command:5}"
@@ -19,10 +40,9 @@ for version in "${versions[@]}"; do
                 tempCommand="/usr/bin/php vendor/bin/${command}"
             fi
         fi
-        cd $TYPO3_PATH
-        message magenta "[TYPO3 v${version}] ${tempCommand}"
-        $tempCommand
-    else
-        message red "TYPO3 instance not found for version ${version}"
     fi
+
+    cd "$exec_dir"
+    message magenta "[TYPO3 v${version} (${mode})] ${tempCommand}"
+    $tempCommand
 done

--- a/commands/web/install
+++ b/commands/web/install
@@ -7,14 +7,30 @@
 ## MutagenSync: true
 
 TYPO3=""
+# MODE selects the installation flavour: "composer" (default) builds a regular
+# Composer instance, "classic" rebuilds the same version slot as a Composer-free
+# (TER-style) instance. It is exported so the sourced .install-<v> wrappers and
+# pre_setup pick it up.
+export MODE="composer"
 for arg in "$@"; do
     case "$arg" in
         -v|--verbose) export VERBOSE=1 ;;
+        --classic)    export MODE=classic ;;
         *) [ -z "$TYPO3" ] && TYPO3="$arg" ;;
     esac
 done
+export MODE
 
 . .ddev/.setup/scripts/utils.sh
+
+# Classic mode is a per-version, v12+ feature — reject the combinations it does
+# not support before dispatching. "all" is caught up front; the v11 guard runs
+# after the version has been resolved so it also covers the implicit lowest
+# version (`ddev install --classic`).
+if [ "$MODE" = "classic" ] && [ "$TYPO3" = "all" ]; then
+    message red "Classic mode is per-version only, e.g. 'ddev install 13 --classic'."
+    exit 1
+fi
 
 if [ "$TYPO3" == "all" ]; then
     mapfile -t versions < <(get_supported_typo3_versions)
@@ -28,6 +44,10 @@ else
         if ! check_typo3_version "$TYPO3"; then
             exit 1
         fi
+    fi
+    if [ "$MODE" = "classic" ] && [ "$TYPO3" = "11" ]; then
+        message red "Classic mode requires TYPO3 v12 or higher."
+        exit 1
     fi
     ".ddev/commands/web/.install-$TYPO3"
 fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -142,3 +142,50 @@ JSON
   run ddev install 13
   assert_success
 }
+
+# End-to-end confirmation that a classic (non-Composer) install rebuilds the
+# version slot in place: the mode marker flips to "classic", the extension is
+# symlinked TER-style into typo3conf/ext/<key>, and the frontend is reachable
+# under the unchanged hostname.
+# bats test_tags=install
+@test "ddev install 13 --classic builds a classic instance" {
+  set -eu -o pipefail
+  if [ "${RUN_DDEV_INSTALL:-false}" != "true" ]; then
+    skip "set RUN_DDEV_INSTALL=true to run the networked 'ddev install' assertion"
+  fi
+
+  scaffold_with_existing_tests_dir
+
+    # Authenticate composer to avoid codeload rate-limit (HTTP 400) on TYPO3 subtree-split
+    # packages. Scope to THIS temp project (no `global`) so the token lives only in
+    # ${TESTDIR}/.ddev and is removed by teardown — never persisted to the user's global config.
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+      run ddev config --web-environment-add="COMPOSER_AUTH={\"github-oauth\":{\"github.com\":\"${GITHUB_TOKEN}\"}}"
+      assert_success
+      run ddev restart -y
+      assert_success
+    fi
+
+  run ddev install 13 --classic
+  assert_success
+
+  local ext_key
+  ext_key=$(echo "${PROJNAME}" | tr '-' '_')
+
+  # Mode marker flipped to classic.
+  run cat "${TESTDIR}/.Build/13/.install-mode"
+  assert_success
+  assert_output "classic"
+
+  # Extension linked TER-style into typo3conf/ext/<key>: the target is a
+  # directory whose entries are symlinks back to the extension sources (here the
+  # scaffolded composer.json), and there is no per-extension Composer autoloader.
+  assert_dir_exist "${TESTDIR}/.Build/13/public/typo3conf/ext/${ext_key}"
+  run test -L "${TESTDIR}/.Build/13/public/typo3conf/ext/${ext_key}/composer.json"
+  assert_success
+  assert_file_not_exist "${TESTDIR}/.Build/13/public/typo3conf/ext/${ext_key}/vendor/autoload.php"
+
+  # Frontend reachable under the unchanged per-version hostname.
+  run curl -sfI "https://13.${PROJNAME}.ddev.site"
+  assert_success
+}


### PR DESCRIPTION
## The Issue

Every TYPO3 instance this add-on provisions runs in **Composer mode**. That leaves a whole class of bugs invisible — the ones that only surface on a classic (non-Composer) TER installation:

- class loading driven by the `autoload` key in `ext_emconf.php` instead of Composer's PSR-4 autoloader
- extension-key resolution
- runtime PHP dependencies that only happen to exist because Composer pulled them in

To reproduce these, developers currently have to spin up a separate classic environment by hand.

## How This PR Solves The Issue

Adds an opt-in `--classic` flag to `ddev install <v>` that **rebuilds the same version slot in place** as a Composer-free instance:

- **Slot overwrite, not a new instance** — the classic build lives in `.Build/<v>`, so the existing wildcard vhost keeps serving it under the unchanged `<v>.<ext>.ddev.site` hostname. No new hostnames, command files, or routing changes (`apache/*`, `install.yaml`, `launch` untouched).
- **TER-faithful layout** — TYPO3 sources are downloaded from `get.typo3.org` (no `composer install`); the source symlink trio (`typo3_src`, `typo3`, `index.php`) is wired up and the shipped `_.htaccess` copied into the docroot. The main extension and fixture packages are symlinked into `typo3conf/ext/<key>`, so class loading is driven by `ext_emconf.php` (v12/v13) resp. the extension's `composer.json` (v14) — exactly the fidelity this mode exists to test.
- **Explicit activation** — classic mode does not auto-activate extensions, so they are activated the classic (PackageStates) way via the core CLI, followed by `extension:setup`.
- **Mode marker** — a per-slot `.Build/<v>/.install-mode` file records `composer`/`classic`. The exec wrappers (`ddev 12|13|14 …` and `ddev all …`) read it to choose the core CLI binary + `public/` working directory, and reject `composer` commands on a classic slot (missing marker → `composer` fallback).
- **Mode-aware fixtures** — `import_site_configs` writes to `public/typo3conf/sites` in classic mode (vs. `config/sites` in Composer mode); the XML/SQL import helpers work unchanged since they use `$TYPO3_BIN` and `public/` paths in the same slot.
- **Guards** — classic mode is per-version and v12+ only: `ddev install all --classic` and `ddev install 11 --classic` fail with a clear message.

The Composer path is fully backward compatible — without `--classic`, behaviour is identical to before (it now just also writes a `composer` mode marker).

## Manual Testing Instructions

```shell
# Composer path unchanged; slot marker is "composer"
ddev install 13
cat .Build/13/.install-mode        # -> composer

# Classic rebuild of the same slot
ddev install 13 --classic
cat .Build/13/.install-mode        # -> classic
ls -l .Build/13/public/typo3_src .Build/13/public/typo3 .Build/13/public/index.php
ls -l .Build/13/public/typo3conf/ext/<extension_key>   # symlinked, no vendor autoloader

# Frontend + backend under the unchanged hostname
ddev launch 13
ddev launch 13 /typo3

# Mode auto-detected by the exec wrappers
ddev 13 typo3 cache:flush          # runs via core binary
ddev 13 composer du -o             # rejected with a clear message on a classic slot
ddev all typo3 cache:flush         # handles mixed composer/classic slots

# Guards
ddev install all --classic         # error: per-version only
ddev install 11 --classic          # error: requires v12 or higher

# Autoload-fidelity check (v12/v13): removing the `autoload` key from
# ext_emconf.php must break the classic instance while the Composer install
# keeps working. On v14, removing the extension's composer.json must make the
# classic instance stop recognising the extension.
```

## Automated Testing Overview

Adds a bats test (`ddev install 13 --classic builds a classic instance`) asserting the `.install-mode` marker flips to `classic`, the extension is symlinked TER-style into `typo3conf/ext/<key>` without a per-extension Composer autoloader, and the frontend is reachable under the unchanged hostname. It is tagged `install` and gated behind `RUN_DDEV_INSTALL=true`, matching the existing networked end-to-end test, so it is skipped by default in CI (which does not exercise `ddev install`).

## Release/Deployment Notes

- Purely additive and opt-in; the default Composer install path is unchanged and remains the behaviour for `ddev install` / `ddev install all`.
- No routing, hostname, or `install.yaml` changes — nothing to reconfigure on existing projects.
- Two points worth verifying against a live target version during review (called out in code comments): that the hidden core CLI commands `extension:activate` / `extension:deactivate` still exist in v13/v14 classic (documented for v11/v12; otherwise fall back to writing the PackageStates entry programmatically), and that `typo3 setup` provisions the expected classic directory structure (`fileadmin`, `typo3temp`, `typo3conf/system/settings.php`). These could not be exercised in a live TYPO3 runtime here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019JVCamuSaBdbntKfn8N1Jn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Classic (non-Composer) installation support for TYPO3 versions 12–14.
  * Added the `ddev install <version> --classic` option.
  * Classic and Composer installations now display their mode and use the appropriate command execution paths.
  * Added mode-aware handling for TYPO3 CLI commands, site configuration, extensions, and frontend access.

* **Documentation**
  * Added comprehensive Classic mode installation and usage guidance.

* **Tests**
  * Added end-to-end coverage for Classic TYPO3 13 installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->