### PR TITLE
fix: terminate the heredoc that generates config.typo3-setup.yaml

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -82,6 +82,7 @@ post_install_actions:
     hooks:
        post-start:
         - exec: mkdir -p /var/www/html/.Build/ && cp /var/www/html/.ddev/.setup/templates/* /var/www/html/.Build/
+    EOF
 
   - |
     #ddev-description:Create Tests folder


### PR DESCRIPTION
## Summary

- Close the unterminated `cat <<EOF` heredoc in the *"Create a config.typo3-setup.yaml"* post-install action.

## Changes

- `install.yaml` - add the missing `EOF` delimiter after the `hooks:` block

## Verification

The unterminated heredoc is silently accepted by macOS's bash 3.2 (no warning), but bash 5 (Linux, used in CI and inside the DDEV web container) emits `warning: here-document at line N delimited by end-of-file (wanted 'EOF')`. Reproduced both states by running the exact YAML-dedented script under `bash:5` in Docker:

- Before: warning present
- After: no warning, generated `config.typo3-setup.yaml` byte-identical

Also ran `ddev add-on get` end-to-end against a scratch project — output unchanged, no regressions.

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the post-install setup so the configuration file is created correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->