### PR TITLE
fix: utils.sh, index.php and version 12-14 command wrappers are missing the #ddev-generated marker

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
 
 # Verbose flag — set VERBOSE=1 (or pass -v/--verbose to `ddev install`) to
 # disable the spinner and stream all command output live.

--- a/.setup/templates/index.php
+++ b/.setup/templates/index.php
@@ -1,4 +1,7 @@
 <?php
+// #ddev-generated
+// If you want to take over this file and customize it, remove the line above
+// and ddev will respect it and won't overwrite the file.
 declare(strict_types=1);
 
 $extensionKey = getenv('EXTENSION_NAME');

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ For a detailed console output, use the following command:
 ddev install 12 -v
 ````
 
+### Updating
+
+Run `ddev add-on get konradmichalik/ddev-typo3-multi-version-extension && ddev restart` again to pick up add-on updates in an existing project.
+
+Files that ship with a `#ddev-generated` marker (e.g. `.ddev/.setup/scripts/utils.sh`, `.ddev/.setup/templates/index.php`, the `commands/web/*` wrappers) are overwritten on every update. If you need to customize one of them, remove that marker line from your project's copy — DDEV will then leave the file alone on future updates.
+
 ## ⚙ Configuration
 
 By default, a blank TYPO3 instance will be installed for each version. They are only two extensions installed:

--- a/commands/web/.install-12
+++ b/commands/web/.install-12
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
+## #ddev-generated
 . .ddev/.setup/scripts/utils.sh
 
 # Pre-setup function for TYPO3 version 12.

--- a/commands/web/.install-13
+++ b/commands/web/.install-13
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
+## #ddev-generated
 . .ddev/.setup/scripts/utils.sh
 
 # Pre-setup function for TYPO3 version 13.

--- a/commands/web/.install-14
+++ b/commands/web/.install-14
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
+## #ddev-generated
 . .ddev/.setup/scripts/utils.sh
 
 # Pre-setup function for TYPO3 version 14

--- a/commands/web/12
+++ b/commands/web/12
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+## #ddev-generated
 ## Description: Exec command for TYPO3 instance 12.
 ## Usage: 12
 ## Example: "ddev 12 composer du -o" or "ddev 12 typo3 cache:flush"

--- a/commands/web/13
+++ b/commands/web/13
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+## #ddev-generated
 ## Description: Exec command for TYPO3 instance 13.
 ## Usage: 13
 ## Example: "ddev 13 composer du -o" or "ddev 13 typo3 cache:flush"

--- a/commands/web/14
+++ b/commands/web/14
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+## #ddev-generated
 ## Description: Exec command for TYPO3 instance 14.
 ## Usage: 14
 ## Example: "ddev 14 composer du -o" or "ddev 14 typo3 cache:flush"

--- a/commands/web/all
+++ b/commands/web/all
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+## #ddev-generated
 ## Description: Exec command for all TYPO3 instances.
 ## Usage: all
 ## Example: "ddev all composer du -o" or "ddev all typo3 cache:flush"


### PR DESCRIPTION
## Summary

- DDEV only re-copies a `project_files` entry on `ddev add-on get` (update) if the file contains the `#ddev-generated` signature. Files without it are silently frozen at whatever version was present on first install, forever - including bug fixes.
- `.setup/scripts/utils.sh` and `.setup/templates/index.php` never had the signature at all.
- `commands/web/.install-12/13/14` and `commands/web/12/13/14/all` are missing it due to copy-paste drift - their `11`-suffixed siblings have it, these don't, despite being otherwise byte-identical apart from that line.

## Changes

- `.setup/scripts/utils.sh` - add the `#ddev-generated` marker
- `.setup/templates/index.php` - add the marker (as a PHP comment)
- `commands/web/.install-12`, `.install-13`, `.install-14` - add the marker, matching `.install-11`
- `commands/web/12`, `13`, `14`, `all` - add the marker, matching `commands/web/11`
- `README.md` - document the marker/take-over convention under a new "Updating" section

## Verification

Reproduced the bug live: installed the add-on into a scratch project, then re-ran `ddev add-on get --verbose` against a modified local copy - `NOT overwriting <path>. The #ddev-generated signature was not found in the file` for both `utils.sh` and `index.php`.

After the fix: deleted the stale destination copies once (as DDEV's own message instructs), re-ran `ddev add-on get`, then ran it a *second* time to confirm the files are now genuinely kept in sync on every future update (not just re-created once) - all previously-frozen files now show `👍` on both runs.

Closes #36