### PR TITLE
fix: SYMLINK_EXCLUSIONS is declared but never read

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -291,7 +291,8 @@ function setup_environment() {
 # It iterates over the items in the current directory, excluding certain directories and files,
 # and creates symbolic links for the remaining items in the specified base path.
 function create_symlinks_main_extension() {
-    local exclusions=(".*" "Documentation" "Documentation-GENERATED-temp" "var")
+    local exclusions=()
+    read -r -a exclusions <<< "${SYMLINK_EXCLUSIONS:-Documentation Documentation-GENERATED-temp var}"
     for item in ./*; do
         local base_name=$(basename "$item")
         for exclusion in "${exclusions[@]}"; do

--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -292,7 +292,7 @@ function setup_environment() {
 # and creates symbolic links for the remaining items in the specified base path.
 function create_symlinks_main_extension() {
     local exclusions=()
-    read -r -a exclusions <<< "${SYMLINK_EXCLUSIONS:-Documentation Documentation-GENERATED-temp var}"
+    read -r -a exclusions <<< "${SYMLINK_EXCLUSIONS:-Documentation Documentation-GENERATED-temp var vendor public}"
     for item in ./*; do
         local base_name=$(basename "$item")
         for exclusion in "${exclusions[@]}"; do

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ If you need more extensions for your setup, you can place them in the `Tests/Acc
 > [!NOTE]
 > You may not need all TYPO3 versions? You can remove the unwanted versions from the `TYPO3_VERSIONS` variable in [.ddev/docker-compose.typo3-setup.yaml](docker-compose.typo3-setup.yaml).
 
+Items from your main extension's root directory are symlinked into the TYPO3 instance, except the ones listed in the `SYMLINK_EXCLUSIONS` variable in [.ddev/docker-compose.typo3-setup.yaml](docker-compose.typo3-setup.yaml). It defaults to `Documentation Documentation-GENERATED-temp var vendor public`, so a local `vendor/` or `public/` directory in your extension repository is not linked into the instance's own composer/web-root structure.
+
 ### Fixtures
 
 During installation, fixture data from `Tests/Acceptance/Fixtures/` is automatically imported. The following types are supported:

--- a/docker-compose.typo3-setup.yaml
+++ b/docker-compose.typo3-setup.yaml
@@ -6,7 +6,7 @@ services:
             - EXTENSION_NAME=custom-extension-key
             - PACKAGE_NAME=vendor/custom-extension-key
             - TYPO3_VERSIONS=12 13 14
-            - SYMLINK_EXCLUSIONS=.* Documentation Documentation-GENERATED-temp var vendor public
+            - SYMLINK_EXCLUSIONS=Documentation Documentation-GENERATED-temp var vendor public
 
             # TYPO3 v11 and v12 config
             - TYPO3_INSTALL_DB_DRIVER=mysqli


### PR DESCRIPTION
## Summary

- `create_symlinks_main_extension()` used a hardcoded exclusion list instead of the `SYMLINK_EXCLUSIONS` env var already declared in `docker-compose.typo3-setup.yaml` - the variable had no effect, and the two lists disagreed (the env var additionally listed `vendor`/`public`, which were therefore symlinked into the build despite the declared intent to exclude them).
- The `.*` entry in both lists was dead code: `for item in ./*` never yields dotfiles/dotdirs in bash without `dotglob`, so it could never match anything. Removed from both.

## Changes

- `.setup/scripts/utils.sh` - read `SYMLINK_EXCLUSIONS`, falling back to the previous default (minus the dead `.*` entry)
- `docker-compose.typo3-setup.yaml` - drop the dead `.*` entry from the default value
- `README.md` - document the variable and the new default (including the vendor/public exclusion behavior change)

## Behavior change

Consumers who update via `ddev add-on get` (now possible at all thanks to #37) will get `vendor` and `public` excluded from symlinking by default, since the shipped `docker-compose.typo3-setup.yaml` already listed them. Worth calling out in release notes.

## Verification

Unit-tested `create_symlinks_main_extension()` inside a real Linux container (`ubuntu:24.04`, matching the DDEV web container's GNU coreutils, since macOS's BSD `ln` doesn't support the `-r` flag this function relies on):

- Without `SYMLINK_EXCLUSIONS` set (fallback default): `vendor` and `public` are still linked (matches current/old behavior for repos that haven't updated their compose file).
- With `SYMLINK_EXCLUSIONS` set to the value now shipped in `docker-compose.typo3-setup.yaml`: only `Classes`, `Configuration`, `composer.json` are linked - `Documentation`, `var`, `vendor`, `public` are correctly excluded.

Also reproduced this against the real DDEV web container (`ddev exec`) with production env vars, same result.

Stacked on #37 (needed so this change to `utils.sh` actually reaches existing installs).

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable exclusions for symlinked extension content through the `SYMLINK_EXCLUSIONS` setting.
  * Added clear documentation of the default excluded directories.

* **Bug Fixes**
  * Symlink setup no longer automatically excludes every hidden path; only explicitly configured directories are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->