### PR TITLE
fix: make Apache vhost routing independent of the project name

### DIFF
--- a/apache/10.conf
+++ b/apache/10.conf
@@ -3,7 +3,7 @@
 # and ddev will respect it and won't overwrite the file.
 # See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-apache-configuration
 <VirtualHost *:80>
-    ServerName custom-extension-key.ddev.site
+    ServerName ${DDEV_SITENAME}.${DDEV_TLD}
     DocumentRoot /var/www/html/.Build
     <Directory "/var/www/html/.Build">
   		AllowOverride All
@@ -21,7 +21,7 @@
 </VirtualHost>
 
 <VirtualHost *:443>
-    ServerName custom-extension-key.ddev.site
+    ServerName ${DDEV_SITENAME}.${DDEV_TLD}
     DocumentRoot /var/www/html/.Build
     <Directory "/var/www/html/.Build">
   		AllowOverride All

--- a/apache/20.conf
+++ b/apache/20.conf
@@ -3,8 +3,8 @@
 # and ddev will respect it and won't overwrite the file.
 # See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-apache-configuration
 <VirtualHost *:80>
-    ServerName sub.custom-extension-key.ddev.site
-    ServerAlias *.custom-extension-key.ddev.site
+    ServerName sub.${DDEV_SITENAME}.${DDEV_TLD}
+    ServerAlias *.${DDEV_SITENAME}.${DDEV_TLD}
     DocumentRoot /var/www/html/.Build
     <Directory "/var/www/html/.Build">
   		AllowOverride All
@@ -12,7 +12,7 @@
 	</Directory>
 
     RewriteEngine On
-    RewriteCond %{HTTP_HOST} ^([a-z0-9-]+)\.custom-extension-key\.ddev\.site$
+    RewriteCond %{HTTP_HOST} ^(1[1-4])\.
     RewriteRule ^(.*)$ /var/www/html/.Build/%1/public/$1 [L]
 
     RewriteCond %{HTTP:X-Forwarded-Proto} =https
@@ -25,8 +25,8 @@
 </VirtualHost>
 
 <VirtualHost *:443>
-    ServerName sub.custom-extension-key.ddev.site
-    ServerAlias *.custom-extension-key.ddev.site
+    ServerName sub.${DDEV_SITENAME}.${DDEV_TLD}
+    ServerAlias *.${DDEV_SITENAME}.${DDEV_TLD}
     DocumentRoot /var/www/html/.Build
     <Directory "/var/www/html/.Build">
   		AllowOverride All
@@ -34,7 +34,7 @@
 	</Directory>
 
     RewriteEngine On
-    RewriteCond %{HTTP_HOST} ^([a-z0-9-]+)\.custom-extension-key\.ddev\.site$
+    RewriteCond %{HTTP_HOST} ^(1[1-4])\.
     RewriteRule ^(.*)$ /var/www/html/.Build/%1/public/$1 [L]
 
     RewriteCond %{HTTP:X-Forwarded-Proto} =https

--- a/install.yaml
+++ b/install.yaml
@@ -64,8 +64,6 @@ post_install_actions:
     fi
     
     echo "Set extension key to ${extension_key} and extension name to ${extension_name} in"
-    echo " - .ddev/apache/10.conf"
-    echo " - .ddev/apache/20.conf"
     echo " - .ddev/docker-compose.typo3-setup.yaml"
   - |
     #ddev-description:Create a config.typo3-setup.yaml


### PR DESCRIPTION
## Summary

- `apache/10.conf` and `apache/20.conf` had the project name baked in at install time via `sed`. Because `.ddev/` is committed, a `git worktree` checkout inherits the *original* project name while DDEV derives a *new* one from the worktree directory - no vhost matches, requests fall through to the default vhost and serve the intro page instead of the TYPO3 instance.
- Apache resolves `${VAR}` from the container environment at parse time, and DDEV exports `DDEV_SITENAME`/`DDEV_TLD` into the web container, so the project name doesn't need to be baked in at all.

## Changes

- `apache/10.conf`, `apache/20.conf` - `ServerName`/`ServerAlias` now interpolate `${DDEV_SITENAME}.${DDEV_TLD}`; the version-routing `RewriteCond` matches the version label (`^(1[1-4])\.`) instead of the literal hostname, so `ServerAlias` stays scoped without a catch-all `*.ddev.site` vhost
- `install.yaml` - the post-install action no longer claims to rewrite the two Apache files (the blanket `sed` is still needed for `docker-compose.typo3-setup.yaml`, but it's now a no-op on the Apache confs since they no longer contain the placeholder string)

## Verification

Installed into a scratch DDEV project (`wt-scratch`) and confirmed live:

- `apachectl -S` resolves the vhosts correctly: `sub.wt-scratch.ddev.site` as a namevhost with `wild alias *.wt-scratch.ddev.site` - `${DDEV_SITENAME}`/`${DDEV_TLD}` interpolate correctly in the vhost context.
- `curl https://wt-scratch.ddev.site/` serves the intro page.
- `curl https://13.wt-scratch.ddev.site/...` and `https://14.wt-scratch.ddev.site/...` correctly route to `.Build/13/public/...` and `.Build/14/public/...` respectively.
- Neither `apache/10.conf` nor `apache/20.conf` contains any project-specific string anymore.

Per-project container isolation means a second checkout with a different project name is served by its own container with its own env vars - no additional live test needed to confirm no cross-project collision.

Stacked on #37 (this branch's base).

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP and HTTPS routing to use the configured site name and domain automatically.
  * Refined subdomain rewrite matching to support only the intended `11`–`14` subdomains.

* **Chores**
  * Simplified post-install output by removing references to generated Apache configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->