### PR TITLE
fix: trustedHostsPattern is pinned to the install-time hostname

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -335,7 +335,7 @@ function setup_typo3() {
     $TYPO3_BIN configuration:set 'FE/debug' 1
     $TYPO3_BIN configuration:set 'SYS/devIPmask' '*'
     $TYPO3_BIN configuration:set 'SYS/displayErrors' 1
-    $TYPO3_BIN configuration:set 'SYS/trustedHostsPattern' "$VERSION.$EXTENSION_NAME.ddev.site"
+    $TYPO3_BIN configuration:set 'SYS/trustedHostsPattern' '.*'
     $TYPO3_BIN configuration:set 'MAIL/transport' 'smtp'
     $TYPO3_BIN configuration:set 'MAIL/transport_smtp_server' 'localhost:1025'
     $TYPO3_BIN configuration:set 'GFX/processor' 'ImageMagick'


### PR DESCRIPTION
## Summary

- `setup_typo3()` pinned `SYS/trustedHostsPattern` to a single literal hostname derived from `EXTENSION_NAME`. In a worktree that pattern never matches and TYPO3 rejects the request. Affects all four versions (`setup_typo3()` is called from every version's `post_setup_*`).

## Changes

- `.setup/scripts/utils.sh` - set `SYS/trustedHostsPattern` to `.*` instead of a pinned hostname

This is a throwaway development environment, and DDEV already writes a permissive `trustedHostsPattern` for projects it manages elsewhere - the previously pinned value was strictly more restrictive than the rest of `setup_typo3()` assumes (`BE/debug`, `FE/debug`, `SYS/devIPmask '*'`, `SYS/displayErrors` are all dev-mode values right next to it).

## Verification

Ran a full `ddev install 13`. Before: `configuration:show SYS/trustedHostsPattern` returned `13.<sitename>.ddev.site`. After: returns `.*`. Frontend still returns HTTP 200.

Stacked on #40.

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated local setup configuration to accept requests from all hostnames, preventing hostname-related access issues in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->