### PR TITLE
fix: additional_hostnames is generated statically and collides across worktrees

### DIFF
--- a/commands/host/worktree-init
+++ b/commands/host/worktree-init
@@ -13,8 +13,9 @@ if [ ! -f "$COMPOSE_FILE" ]; then
     exit 1
 fi
 
-typo3_versions=$(grep -oE 'TYPO3_VERSIONS=[0-9 ]+' "$COMPOSE_FILE" | head -1 | cut -d= -f2)
-typo3_versions=${typo3_versions:-"11 12 13 14"}
+if ! typo3_versions=$(grep -oE 'TYPO3_VERSIONS=[0-9 ]+' "$COMPOSE_FILE" | head -1 | cut -d= -f2) || [ -z "$typo3_versions" ]; then
+    typo3_versions="12 13 14"
+fi
 
 override_file=".ddev/config.zz-worktree.local.yaml"
 

--- a/commands/host/worktree-init
+++ b/commands/host/worktree-init
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+## #ddev-generated
+## Description: Regenerate this project's additional_hostnames so a git worktree checkout doesn't collide with the primary checkout's hostnames.
+## Usage: worktree-init
+## Example: "ddev worktree-init"
+
+set -eo pipefail
+
+COMPOSE_FILE=".ddev/docker-compose.typo3-setup.yaml"
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "Could not find $COMPOSE_FILE - is the typo3-multi-version-extension add-on installed?"
+    exit 1
+fi
+
+typo3_versions=$(grep -oE 'TYPO3_VERSIONS=[0-9 ]+' "$COMPOSE_FILE" | head -1 | cut -d= -f2)
+typo3_versions=${typo3_versions:-"11 12 13 14"}
+
+override_file=".ddev/config.zz-worktree.local.yaml"
+
+{
+    echo "#ddev-generated"
+    echo "override_config: true"
+    echo "additional_hostnames:"
+    for version in $typo3_versions; do
+        echo "  - ${version}.${DDEV_PROJECT}"
+    done
+} >"$override_file"
+
+echo "Wrote ${override_file} with hostnames for project '${DDEV_PROJECT}' (versions: ${typo3_versions})."
+echo "Run 'ddev restart' to apply it, then 'ddev install all' to install the TYPO3 instances."

--- a/install.yaml
+++ b/install.yaml
@@ -15,6 +15,7 @@ project_files:
   - apache/10.conf
   - apache/20.conf
   - commands/host/launch
+  - commands/host/worktree-init
   - commands/web/.install-11
   - commands/web/.install-12
   - commands/web/.install-13
@@ -117,4 +118,5 @@ post_install_actions:
 
 removal_actions:
   - rm -f ${DDEV_APPROOT}/.ddev/config.typo3-setup.yaml
+  - rm -f ${DDEV_APPROOT}/.ddev/config.zz-worktree.local.yaml
   - rm -rf ${DDEV_APPROOT}/.ddev/.setup/

--- a/install.yaml
+++ b/install.yaml
@@ -118,5 +118,5 @@ post_install_actions:
 
 removal_actions:
   - rm -f ${DDEV_APPROOT}/.ddev/config.typo3-setup.yaml
-  - rm -f ${DDEV_APPROOT}/.ddev/config.zz-worktree.local.yaml
+  - rm -f "${DDEV_APPROOT}/.ddev/config.zz-worktree.local.yaml"
   - rm -rf ${DDEV_APPROOT}/.ddev/.setup/


### PR DESCRIPTION
## Summary

- `.ddev/config.typo3-setup.yaml` is generated once at add-on install time with the project name expanded literally, and it's committed. Every worktree checkout therefore claims the *same* router hostnames as the primary checkout - two projects can't own `13.<name>.ddev.site` simultaneously. This is the one point that can't be fixed by making files name-agnostic, since `config.yaml` has no templating.
- Side finding: the heredoc hardcodes `11`-`14` while `TYPO3_VERSIONS` defaults to `12 13 14` - a dead `11.<project>` hostname was always registered.

## Changes

- `commands/host/worktree-init` (new) - reads `TYPO3_VERSIONS` out of `.ddev/docker-compose.typo3-setup.yaml` (a host command has no container env, so it can't `printenv`) and `${DDEV_PROJECT}`, then writes `.ddev/config.zz-worktree.local.yaml` with `override_config: true` and matching `additional_hostnames` - only for the versions actually configured, no dead entries.
- `install.yaml` - ship the new command; clean it up in `removal_actions`.

## Design choices, verified rather than assumed

- **File ordering**: DDEV processes `config.*.yaml` files in a way where `config.zz-worktree.local.yaml` reliably wins over `config.typo3-setup.yaml` for conflicting keys (alphabetical - `t` < `z`). Verified live: with both files present, `ddev describe` shows only the override's hostnames.
- **`override_config: true` semantics**: confirmed it *replaces* the list rather than merging it (same live test).
- **Naming for automatic gitignore**: named the file `config.zz-worktree.local.yaml` (not `config.zz-worktree.yaml`) specifically because DDEV's own tracked `.ddev/.gitignore` already contains `/config.*.local.y*ml` - so the generated file is ignored automatically, no changes to the project's own `.gitignore` needed. Verified with `git check-ignore`.

## Verification

Ran `ddev worktree-init` against the scratch project (`TYPO3_VERSIONS=12 13 14`): generated file contained exactly `12.wt-scratch`, `13.wt-scratch`, `14.wt-scratch` - no `11.*`. `ddev restart` + `ddev describe` reflected exactly those hostnames. `git status` (in a throwaway `git init` of the scratch dir) confirmed the generated file is untracked and ignored.

Stacked on #41.

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a worktree initialization command that validates the TYPO3 setup and configures version-specific hostnames.
  * Displays the restart and installation commands needed to complete setup.

* **Bug Fixes**
  * Worktree-specific configuration is now removed during project cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->