### PR TITLE
feat: use DDEV_SITENAME instead of EXTENSION_NAME for URL output

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -239,7 +239,8 @@ function post_setup() {
   _progress " ├─ Update TYPO3"
     update_typo3
   _done
-  printf " └─ \033[33mTYPO3 $VERSION setup completed!\033[0m Open in your browser: https://$VERSION.${DDEV_SITENAME}.${DDEV_TLD}\n"
+  printf " └─ \033[33mTYPO3 %s setup completed!\033[0m Open in your browser: https://%s.%s.%s\n" \
+    "$VERSION" "$VERSION" "$DDEV_SITENAME" "$DDEV_TLD"
 }
 
 # Function to display an introductory message for the TYPO3 version.

--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -239,7 +239,7 @@ function post_setup() {
   _progress " ├─ Update TYPO3"
     update_typo3
   _done
-  printf " └─ \033[33mTYPO3 $VERSION setup completed!\033[0m Open in your browser: https://$VERSION.${EXTENSION_NAME}.ddev.site\n"
+  printf " └─ \033[33mTYPO3 $VERSION setup completed!\033[0m Open in your browser: https://$VERSION.${DDEV_SITENAME}.${DDEV_TLD}\n"
 }
 
 # Function to display an introductory message for the TYPO3 version.

--- a/.setup/templates/index.php
+++ b/.setup/templates/index.php
@@ -5,6 +5,7 @@
 declare(strict_types=1);
 
 $extensionKey = getenv('EXTENSION_NAME');
+$siteHostname = getenv('DDEV_SITENAME') . '.' . getenv('DDEV_TLD');
 $typo3AdminUser = getenv('TYPO3_SETUP_ADMIN_USERNAME');
 $typo3AdminPassword = getenv('TYPO3_SETUP_ADMIN_PASSWORD');
 $supportedVersions = explode(' ', getenv('TYPO3_VERSIONS'));
@@ -49,7 +50,7 @@ if (file_exists($composerJsonPath)) {
     foreach ($supportedVersions as $version) {
         $directoryPath = '/var/www/html/.Build/' . $version;
         if (is_dir($directoryPath)) {
-            echo "<article class='flex'><kbd>{$version}</kbd><div><strong>Frontend</strong><br/><strong>Backend</strong></div><div><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site'>https://{$version}.{$extensionKey}.ddev.site</a><br/><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site/typo3/?u={$typo3AdminUser}&p={$typo3AdminPassword}'>https://{$version}.{$extensionKey}.ddev.site/typo3</a></div></article>";
+            echo "<article class='flex'><kbd>{$version}</kbd><div><strong>Frontend</strong><br/><strong>Backend</strong></div><div><a target='_blank' href='https://{$version}.{$siteHostname}'>https://{$version}.{$siteHostname}</a><br/><a target='_blank' href='https://{$version}.{$siteHostname}/typo3/?u={$typo3AdminUser}&p={$typo3AdminPassword}'>https://{$version}.{$siteHostname}/typo3</a></div></article>";
         } else {
             echo "<article>Version {$version} is not installed. Run <code>ddev install {$version}</code> to install.</article>";
         }


### PR DESCRIPTION
## Summary

- `EXTENSION_NAME` serves two unrelated purposes: extension identity and hostname base. Only the latter is unstable across worktrees. Two remaining places still built URLs from it: the `ddev install` completion message and the intro page's frontend/backend links.
- `commands/host/launch` already does this correctly by reading the hostname at runtime - applying that pattern consistently.

## Changes

- `.setup/scripts/utils.sh` - completion message now builds the URL from `${DDEV_SITENAME}`/`${DDEV_TLD}`
- `.setup/templates/index.php` - a new `$siteHostname` (from `DDEV_SITENAME`/`DDEV_TLD`) drives the frontend/backend links; `$extensionKey` (still `EXTENSION_NAME`) is kept for the page title/heading, which is genuine extension-identity display, not a hostname

`EXTENSION_NAME`, `EXTENSION_KEY`, `PACKAGE_NAME` are untouched everywhere else - they express extension identity and must stay identical across worktrees.

## Verification

Deployed to a scratch project and fetched the real intro page through Apache+PHP-FPM (not just a CLI check) - confirms `DDEV_SITENAME`/`DDEV_TLD` are visible to PHP-FPM's `getenv()`, not just shell context:

```
href='https://13.wt-scratch.ddev.site'
href='https://13.wt-scratch.ddev.site/typo3/?u=admin&p=Password1!'
```

Also confirmed the completion message ignores `EXTENSION_NAME` even when set to a different value than `DDEV_SITENAME`.

Stacked on #42.

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated setup completion messages and generated links to use the configured site name and top-level domain.
  * TYPO3 frontend and backend URLs now correctly reflect the active site hostname instead of a fixed default domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->