### PR TITLE
docs: document git worktree usage and raise the DDEV version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,48 @@ You can also run a command in all TYPO3 instances at once:
 ddev all typo3 cache:flush
 ```
 
+## 🌳 Git Worktree Support
+
+Since `.ddev/` is committed to your repository, a plain `git worktree add` checkout would normally share the same DDEV project name (and therefore the same hostnames) as your primary checkout - only one of them could run at a time. This add-on avoids baking the project name into any of its own files, but DDEV's own `.ddev/config.yaml` still needs one adjustment, and each worktree needs its own hostnames.
+
+Requires DDEV `>= v1.24.10` (the version constraint declared by this add-on).
+
+### One-time setup
+
+Tell DDEV to derive the project name from the directory instead of a fixed `name:` in `.ddev/config.yaml` - either per project by removing the `name:` line from `.ddev/config.yaml`, or globally for all future projects:
+
+```shell
+ddev config global --omit-project-name-by-default=true
+```
+
+### Per-worktree setup
+
+Create the worktree as a **sibling** of your primary checkout (never nested inside it), using a directory name that's safe as a DNS label (lowercase letters, digits, hyphens):
+
+```shell
+git worktree add ../my-feature-branch feature/my-feature
+cd ../my-feature-branch
+ddev worktree-init
+ddev restart
+ddev install all
+```
+
+`ddev worktree-init` regenerates this checkout's router hostnames so they don't collide with the primary checkout's; `.Build/` is gitignored, so every worktree needs its own `ddev install`.
+
+### Resource expectations
+
+Each worktree runs its own `web` and `db` container, plus roughly one full TYPO3 distribution per configured version under `.Build/`. Running several worktrees at once multiplies both. `ddev poweroff` stops *all* DDEV projects, not just the current one - worth knowing if several worktrees (or agents) are meant to keep running in parallel.
+
+### Upgrading an existing project
+
+If you installed this add-on before worktree support was added, re-run the installation command to pick up the fixes:
+
+```shell
+ddev add-on get konradmichalik/ddev-typo3-multi-version-extension && ddev restart
+```
+
+See [Updating](#updating) above for which files get overwritten.
+
 ## Background
 
 The TYPO3 instances are located in the `.Build/` directory. The main extension is symlinked from the root directory to the `.Build/` directory. 

--- a/install.yaml
+++ b/install.yaml
@@ -28,7 +28,7 @@ project_files:
   - commands/web/install
   - docker-compose.typo3-setup.yaml
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'
 
 post_install_actions:
   - |


### PR DESCRIPTION
## Summary

- Worktree support depends on omitting `name:` from `.ddev/config.yaml`, which requires DDEV v1.24.9. v1.24.9 itself shipped a regression that prevented DDEV from updating `/etc/hosts` in CI environments with custom project TLDs, fixed in v1.24.10 - since this add-on runs a bats suite in GitHub Actions, the constraint needs to be `>= v1.24.10`, not `>= v1.24.9`.
- There was no documentation for the worktree setup at all.

## Changes

- `install.yaml` - raise `ddev_version_constraint` to `>= v1.24.10`
- `README.md` - new "Git Worktree Support" section: one-time DDEV config, per-worktree setup (`ddev worktree-init` → `ddev restart` → `ddev install all`), resource expectations, the `ddev poweroff` caveat, and an upgrade note for existing consumers pointing at the `#updating` section added earlier in this stack

## Verification

`ddev add-on get` still succeeds with the raised constraint against the installed DDEV v1.25.3.

This is the last PR in the git-worktree-support milestone stack (#37 → #39 → #40 → #41 → #42 → #43 → this one). Once the whole stack is merged, all of #22-#27 are closed.

Stacked on #43.

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using Git worktrees, including project naming, setup, initialization, resource usage, and upgrading existing installations.

* **Chores**
  * Updated the minimum required DDEV version to v1.24.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->