### PR TITLE
fix: unify the site config template mechanism and placeholder convention

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -434,7 +434,9 @@ function import_sql_data() {
 # Function to import site configuration YAML fixtures.
 # It copies each directory under Tests/Acceptance/Fixtures/sites/ to the
 # TYPO3 site configuration path for the current version, replacing
-# VERSION_PLACEHOLDER with the actual version number in the config.yaml.
+# __VERSION__ with the TYPO3 version and __SITENAME__ with DDEV_SITENAME
+# in config.yaml. VERSION_PLACEHOLDER is still supported for backwards
+# compatibility with fixtures written before __VERSION__ was introduced.
 function import_site_configs() {
     FIXTURE_DIR="/var/www/html/Tests/Acceptance/Fixtures/sites"
 
@@ -453,7 +455,11 @@ function import_site_configs() {
             mkdir -p "$TARGET_BASE/$SITE_NAME"
             cp -r "$SITE_DIR"* "$TARGET_BASE/$SITE_NAME/"
             if [ -f "$TARGET_BASE/$SITE_NAME/config.yaml" ]; then
-                sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" "$TARGET_BASE/$SITE_NAME/config.yaml"
+                sed -i \
+                    -e "s/__VERSION__/$VERSION/g" \
+                    -e "s/VERSION_PLACEHOLDER/$VERSION/g" \
+                    -e "s/__SITENAME__/$DDEV_SITENAME/g" \
+                    "$TARGET_BASE/$SITE_NAME/config.yaml"
             fi
         fi
     done

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ During installation, fixture data from `Tests/Acceptance/Fixtures/` is automatic
 |------|----------|-------------|
 | XML | `Tests/Acceptance/Fixtures/*.xml` | TYPO3 export files, imported via `impexp:import` |
 | SQL | `Tests/Acceptance/Fixtures/*.sql` | Raw SQL files, imported directly into the database |
-| Site config | `Tests/Acceptance/Fixtures/sites/<site-name>/` | Site configuration directories copied to `config/sites/`. Use `VERSION_PLACEHOLDER` in `config.yaml` to insert the TYPO3 version automatically. Use a relative `base: /` - an absolute hostname in `base` breaks as soon as the project's hostname changes (e.g. in a `git worktree` checkout). |
+| Site config | `Tests/Acceptance/Fixtures/sites/<site-name>/` | Site configuration directories copied to `config/sites/`. In `config.yaml`, `__VERSION__` is replaced with the TYPO3 version and `__SITENAME__` with the project's `DDEV_SITENAME`. Use a relative `base: /` - an absolute hostname in `base` breaks as soon as the project's hostname changes (e.g. in a `git worktree` checkout). The older `VERSION_PLACEHOLDER` placeholder still works but is deprecated in favor of `__VERSION__`. |
 | Shell scripts | `Tests/Acceptance/Fixtures/*.sh` | Executed during setup (failures are logged but don't abort the installation) |
 
 ## 📊 Usage


### PR DESCRIPTION
## Summary

- Two incompatible site-config placeholder conventions existed: this add-on's `import_site_configs()` used `VERSION_PLACEHOLDER`, while a locally-added variant in `xima-typo3-frontend-edit` used `__VERSION__`/`__EXTENSION_NAME__` and hardcoded an absolute `base` (exactly the pattern the relative-base fix removes).
- The location (`Tests/Acceptance/Fixtures/sites/`, repo-owned, sits with the other fixtures) was already the right one - only the placeholder syntax needed unifying.

## Changes

- `.setup/scripts/utils.sh`'s `import_site_configs()` now substitutes `__VERSION__` and `__SITENAME__` (from `DDEV_SITENAME`), and still substitutes the old `VERSION_PLACEHOLDER` for backwards compatibility (deprecation window - no single release migrates every external consumer at once)
- `README.md` - documents both placeholders and the relative-base recommendation; notes `VERSION_PLACEHOLDER` is deprecated in favor of `__VERSION__`

## Out of scope

Migrating `xima-typo3-frontend-edit`'s local site-config template off its own variant is a change to a *different* repository - not done here, flagging it as a follow-up rather than pushing to that repo unasked.

## Verification

Deployed a fixture with all three placeholders (`__VERSION__`, `__SITENAME__`, `VERSION_PLACEHOLDER`) in one `config.yaml` and ran a full `ddev install 13`. Imported result:

```yaml
identifier: testsite-13
testSitename: wt-scratch
testOldStyle: 13
```

All three substituted correctly.

Stacked on #44.

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated fixture documentation to support `__VERSION__` and `__SITENAME__` placeholders.
  * Documented `VERSION_PLACEHOLDER` as deprecated while retaining compatibility.

* **Bug Fixes**
  * Improved site configuration fixture imports so version and site name placeholders are replaced correctly.
  * Preserved support for existing `VERSION_PLACEHOLDER` configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->