### PR TITLE
feat: add a --demo install mode for rich demo content

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -230,6 +230,12 @@ function post_setup() {
     fi
   _done
 
+  if [ -n "$DEMO_PROFILE" ]; then
+    _progress " ├─ Install demo content"
+      install_demo
+    _done
+  fi
+
   _progress " ├─ Import data"
     import_xml_data
     import_sql_data
@@ -240,6 +246,44 @@ function post_setup() {
     update_typo3
   _done
   printf " └─ \033[33mTYPO3 $VERSION setup completed!\033[0m Open in your browser: https://$VERSION.${DDEV_SITENAME}.${DDEV_TLD}\n"
+}
+
+# Function to install demo content for the current TYPO3 version, controlled
+# by the DEMO_PROFILE environment variable (set via `ddev install --demo`).
+#
+# Profiles:
+#   introduction (default) - installs typo3/cms-introduction and removes the
+#     generated "main" site, since the Introduction Package brings its own.
+#     Not available on TYPO3 14 (no released version supports it yet) - falls
+#     back to the bootstrap profile with a message instead of failing.
+#   bootstrap - installs bk2k/bootstrap-package only, for a themed but empty
+#     site. Works on every supported version, including 14.
+#   custom - installs no package here; relies entirely on whatever the repo
+#     already provides under Tests/Acceptance/Fixtures/ (XML/SQL/site config/
+#     shell script fixtures, imported later in post_setup()).
+function install_demo() {
+    local profile="${DEMO_PROFILE:-introduction}"
+
+    if [ "$profile" == "introduction" ] && [ "$VERSION" == "14" ]; then
+        message yellow "typo3/cms-introduction has no TYPO3 14 release yet - falling back to the bootstrap profile."
+        profile="bootstrap"
+    fi
+
+    case "$profile" in
+        introduction)
+            composer req typo3/cms-introduction:'*' --no-progress -n -d "$BASE_PATH"
+            $TYPO3_BIN extension:setup --extension=introduction
+            rm -rf "$BASE_PATH/config/sites/main"
+            ;;
+        bootstrap)
+            composer req bk2k/bootstrap-package:'*' --no-progress -n -d "$BASE_PATH"
+            ;;
+        custom) ;;
+        *)
+            message red "Unknown demo profile '$profile'. Supported: introduction, bootstrap, custom."
+            return 1
+            ;;
+    esac
 }
 
 # Function to display an introductory message for the TYPO3 version.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ If you need more extensions for your setup, you can place them in the `Tests/Acc
 > [!NOTE]
 > You may not need all TYPO3 versions? You can remove the unwanted versions from the `TYPO3_VERSIONS` variable in [.ddev/docker-compose.typo3-setup.yaml](docker-compose.typo3-setup.yaml).
 
+### Demo content
+
+Pass `--demo` to `ddev install` to populate the instance with a demo site instead of a single blank page. The demo step always drops and rebuilds the instance rather than layering onto an existing one, so re-running it is deterministic.
+
+```shell
+ddev install 13 --demo
+ddev install 13 --demo=bootstrap
+ddev install all --demo
+```
+
+Profiles:
+
+| Profile | Result |
+|---|---|
+| `introduction` (default) | Installs [`typo3/cms-introduction`](https://extensions.typo3.org/extension/introduction) and removes the generated `main` site, since the Introduction Package brings its own. **Not available on TYPO3 14** - no released version supports it yet, so `--demo`/`--demo=introduction` automatically falls back to the `bootstrap` profile on 14 with a message. |
+| `bootstrap` | Installs [`bk2k/bootstrap-package`](https://packagist.org/packages/bk2k/bootstrap-package) only - a themed but otherwise empty site. Works on every supported version. |
+| `custom` | Installs no demo package; relies entirely on your own `Tests/Acceptance/Fixtures/` fixtures (see below). |
+
 ### Fixtures
 
 During installation, fixture data from `Tests/Acceptance/Fixtures/` is automatically imported. The following types are supported:

--- a/commands/web/install
+++ b/commands/web/install
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
 
 ## #ddev-generated
-## Description: Install TYPO3 instances. Pass -v/--verbose to stream all command output.
-## Usage: install [version|all] [-v|--verbose]
-## Example: "ddev install" or "ddev install 12" or "ddev install all" or "ddev install 14 -v"
+## Description: Install TYPO3 instances. Pass -v/--verbose to stream all command output, --demo[=profile] to install demo content.
+## Usage: install [version|all] [-v|--verbose] [--demo[=profile]]
+## Example: "ddev install" or "ddev install 12" or "ddev install all --demo" or "ddev install 14 -v"
 ## MutagenSync: true
 
 TYPO3=""
+DEMO_PROFILE=""
 for arg in "$@"; do
     case "$arg" in
         -v|--verbose) export VERBOSE=1 ;;
+        --demo) DEMO_PROFILE="introduction" ;;
+        --demo=*) DEMO_PROFILE="${arg#--demo=}" ;;
         *) [ -z "$TYPO3" ] && TYPO3="$arg" ;;
     esac
 done
+[ -n "$DEMO_PROFILE" ] && export DEMO_PROFILE
 
 . .ddev/.setup/scripts/utils.sh
 


### PR DESCRIPTION
## Summary

- `ddev install <v>` produces a bare TYPO3 with a single empty page - not enough to exercise extensions that operate on real content structures (content planner, frontend edit, pagetree facets, heatmap).
- Rebuild semantics: the demo step always drops and rebuilds rather than layering onto an existing instance, so it's a flag on the existing `install` command rather than a separate one (matches the already-drafted `--classic` flag design - one install entry point, orthogonal modifiers).

## Changes

- `commands/web/install` - new `--demo[=profile]` flag, exported as `DEMO_PROFILE` for the `.install-<v>` child process
- `.setup/scripts/utils.sh` - new `install_demo()`, called from `post_setup()` right after version setup and before fixture import:
  - `introduction` (default) - `typo3/cms-introduction`, then removes the generated `main` site
  - `bootstrap` - `bk2k/bootstrap-package` only (themed, empty site)
  - `custom` - installs nothing itself, defers entirely to `Tests/Acceptance/Fixtures/`
- `README.md` - documents the profiles and the v14 limitation

## The TYPO3 14 blocker, and how it's handled

Verified against Packagist just now: `typo3/cms-introduction` 4.7.0 (still the latest stable) requires `typo3/cms-core: ^12.4 || ^13.4 || 13.*.*@dev` - no v14 support in any released version. `bk2k/bootstrap-package` does support v14 (16.0.0).

So on v14, the `introduction` profile (default) prints a clear message and automatically falls back to `bootstrap` instead of failing with a raw Composer dependency error.

## Verification

All tested against a scratch project with real `ddev install` runs:

- `ddev install 13 --demo` - installs `typo3/cms-introduction` 4.7.0, `extension:setup` succeeds, `config/sites/` contains only `introduction` (no leftover `main`), frontend returns HTTP 200 with a full multi-page site (~100KB response, in-page navigation present)
- Re-running `ddev install 13 --demo` - deterministic, still exactly one `introduction` site, no duplication
- `ddev install --demo=bootstrap 13` (flag before the version arg) - installs `bk2k/bootstrap-package`, `config/sites/` still contains `main` (bootstrap doesn't touch site config)
- `ddev install 14 --demo` - prints the fallback message, installs `bk2k/bootstrap-package` 16.0.0 instead of failing, frontend returns HTTP 200
- Plain `ddev install <v>` (no `--demo`) - unchanged, as run repeatedly earlier in this stack

Stacked on #45.

Closes #29