### PR TITLE
feat: show git branch and commit on the intro page

### DIFF
--- a/.setup/scripts/write-git-info.sh
+++ b/.setup/scripts/write-git-info.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+#
+# Writes .Build/.git-info with the current branch, short commit and the
+# project's DDEV sitename, so the intro page can show which checkout it is
+# serving - useful when several git worktrees run in parallel. Runs on every
+# container start (post-start hook). Fails open into empty branch/commit
+# values so a missing git binary, a non-git directory, or a detached HEAD
+# never blocks `ddev start`.
+
+mkdir -p /var/www/html/.Build
+
+branch=""
+commit=""
+if command -v git >/dev/null 2>&1 && git -C /var/www/html rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    branch=$(git -C /var/www/html rev-parse --abbrev-ref HEAD 2>/dev/null)
+    commit=$(git -C /var/www/html rev-parse --short HEAD 2>/dev/null)
+fi
+
+{
+    echo "branch=${branch}"
+    echo "commit=${commit}"
+    echo "dirname=${DDEV_SITENAME}"
+} >/var/www/html/.Build/.git-info

--- a/.setup/templates/index.php
+++ b/.setup/templates/index.php
@@ -10,6 +10,16 @@ $typo3AdminUser = getenv('TYPO3_SETUP_ADMIN_USERNAME');
 $typo3AdminPassword = getenv('TYPO3_SETUP_ADMIN_PASSWORD');
 $supportedVersions = explode(' ', getenv('TYPO3_VERSIONS'));
 
+// Read the git branch/commit/dirname written by the post-start hook, if present.
+$gitInfoPath = __DIR__ . '/.git-info';
+$gitBranch = '';
+$gitCommit = '';
+if (file_exists($gitInfoPath)) {
+    $gitInfo = parse_ini_file($gitInfoPath) ?: [];
+    $gitBranch = $gitInfo['branch'] ?? '';
+    $gitCommit = $gitInfo['commit'] ?? '';
+}
+
 // Check if composer.json exists
 $composerJsonPath = __DIR__ . '/../composer.json';
 if (file_exists($composerJsonPath)) {
@@ -41,6 +51,9 @@ if (file_exists($composerJsonPath)) {
     <h1>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-0.5 -0.5 24 24" id="Typo3-Icon--Streamline-Svg-Logos.svg" height="40" width="40"><path fill="#F49700" d="M9.895582291666667 0.5915863541666667c-0.4094479166666667 0.35015104166666666 -0.7003020833333333 0.7595869791666667 -0.7003020833333333 1.9823292708333333 0 3.32738125 4.19994375 13.322414583333334 7.060448958333334 13.322414583333334 0.32128125 0.004360416666666667 0.6412927083333333 -0.04125625 0.9485583333333334 -0.13522083333333335l-0.0060375 0.0016770833333333334 -0.07309687499999999 0.11725208333333334C14.656414583333333 19.815003125000004 11.685221875 22.70162291666667 9.887244791666667 22.759530208333334L9.832571875000001 22.760416666666668C5.927195833333333 22.760416666666668 0.38405927083333335 10.970137500000002 0.38405927083333335 5.7827270833333335c0 -0.8170270833333334 0.185265 -1.45805625 0.46686645833333335 -1.8563635416666668C2.194099375 2.2849110416666667 6.394071875000001 0.9991703125 9.895582291666667 0.5915863541666667ZM15.379429166666668 0.23958333333333334c3.616366666666667 0 7.236446875 0.5835842708333334 7.236446875 2.6252104166666665 0 4.142515625000001 -2.627055208333333 9.1632 -3.9683864583333337 9.1632 -2.391760416666667 0 -5.372680208333334 -6.652869791666666 -5.372680208333334 -9.980222291666667C13.274809375 0.5304494791666666 13.856541666666667 0.23958333333333334 15.373870833333335 0.23958333333333334h0.0055583333333333335Z" stroke-width="1"></path></svg>
         <?php echo $extensionKey; ?></h1>
+    <?php if ($gitBranch !== '' || $gitCommit !== ''): ?>
+    <p><code><?php echo htmlspecialchars($siteHostname); ?></code><?php if ($gitBranch !== ''): ?> &middot; branch <code><?php echo htmlspecialchars($gitBranch); ?></code><?php endif; ?><?php if ($gitCommit !== ''): ?> &middot; commit <code><?php echo htmlspecialchars($gitCommit); ?></code><?php endif; ?></p>
+    <?php endif; ?>
 </header>
 <main class="container">
     <blockquote><?php echo $description; ?></blockquote>

--- a/install.yaml
+++ b/install.yaml
@@ -10,6 +10,7 @@ pre_install_actions:
 
 project_files:
   - .setup/scripts/utils.sh
+  - .setup/scripts/write-git-info.sh
   - .setup/templates/index.php
   - .setup/Tests/Acceptance/Fixtures/
   - apache/10.conf
@@ -80,7 +81,8 @@ post_install_actions:
       - 14.${DDEV_PROJECT}
     hooks:
        post-start:
-        - exec: mkdir -p /var/www/html/.Build/ && cp /var/www/html/.ddev/.setup/templates/* /var/www/html/.Build/
+        - exec: mkdir -p /var/www/html/.Build/ && cp /var/www/html/.ddev/.setup/templates/* /var/www/html/.Build/ && bash /var/www/html/.ddev/.setup/scripts/write-git-info.sh
+    EOF
 
   - |
     #ddev-description:Create Tests folder


### PR DESCRIPTION
## Summary

- With several worktrees running simultaneously, the intro pages are visually identical - distinguishing them by hostname alone is error-prone, both for a human and for an agent reporting back which environment it tested against.

## Design choice vs. the original proposal

The issue as drafted proposed adapting `netresearch/typo3-ddev-skill`'s `pre-start-git-info` host hook, which writes a `docker-compose.git-info.yaml` override with the values as build args/env vars. Went a simpler route instead: extended the **existing** `post-start` hook (already in `config.typo3-setup.yaml`, already runs on every `ddev start`/`restart`) to also run a small script that writes `.Build/.git-info` (plain `key=value` file). Rationale:

- No new `docker-compose.*.yaml` override to gitignore
- No new host-side command
- No container recreate - env-var changes in a compose file force a container recreate on restart; this approach doesn't touch compose at all

## Changes

- `.setup/scripts/write-git-info.sh` (new) - writes `.Build/.git-info` with `branch`, `commit` (from `git -C /var/www/html`) and `dirname` (`DDEV_SITENAME`). Fails open into empty branch/commit if `git` is missing, the directory isn't a git repo, or `HEAD` is detached - never blocks `ddev start`.
- `install.yaml` - the post-start hook now also runs this script; also closes the same unterminated heredoc as #20 (this branch's `install.yaml` history didn't include that fix - flagging so the eventual merge order is understood, the duplicate one-line fix should merge cleanly either way)
- `.setup/templates/index.php` - reads `.git-info` and renders hostname/branch/commit under the page title when available

## Verification

Deployed to the scratch project and tested all three states:

- Non-git directory: `.git-info` contains empty `branch=`/`commit=` - page renders without the branch/commit line (no PHP warnings)
- Real git repo on `feature/my-test-branch`: `.git-info` shows `branch=feature/my-test-branch`, `commit=e769146` - confirmed in the actual rendered page: `wt-scratch.ddev.site · branch feature/my-test-branch · commit e769146`
- Switched to `another-branch` and ran `ddev restart`: values updated to match, no container recreate (no compose file touched)

Stacked on #45.

Closes #30