### PR TITLE
feat: repo-owned configuration file for install customizations

### DIFF
--- a/.setup/project.sh.example
+++ b/.setup/project.sh.example
@@ -1,0 +1,39 @@
+# .ddev/.setup/project.sh — repo-owned customizations for `ddev install`.
+#
+# Copy this file to .ddev/.setup/project.sh and adjust it. It is sourced by
+# utils.sh on every install, and it survives `ddev add-on get` upgrades since
+# it isn't managed by the add-on. Delete anything you don't need.
+#
+# $VERSION expands at use time, not when this file is sourced — write it
+# single-quoted (or with \$VERSION inside a double-quoted string) so it
+# reaches the composer command literally and gets substituted per version.
+
+# Extra composer packages installed alongside the base install.
+ADDITIONAL_PACKAGES=(
+    'typo3/cms-reports:^$VERSION'
+    'typo3/cms-lowlevel:^$VERSION'
+)
+
+# Replaces the default test/sitepackage when set.
+SITEPACKAGE_PACKAGES=(
+    'konradmichalik/routing-test:*@dev'
+)
+
+# Extra `composer config` entries (key and value, space-separated).
+COMPOSER_CONFIG=(
+    'allow-plugins.helhum/dotenv-connector true'
+)
+
+# Extra `typo3 configuration:set` calls (path and value, space-separated).
+# Use \$DDEV_SITENAME (escaped) if the value should reflect the current
+# checkout's hostname rather than a fixed one.
+TYPO3_SETTINGS=(
+    "MAIL/defaultMailFromAddress no-reply@\${DDEV_SITENAME}.ddev.site"
+    'MAIL/defaultMailFromName "My Project"'
+)
+
+# Extra directories (besides Tests/Acceptance/Fixtures/packages) whose
+# subdirectories should be symlinked in as additional extensions.
+FIXTURE_EXTENSION_DIRS=(
+    'Tests/Functional/Fixtures/Extensions'
+)

--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -4,6 +4,12 @@
 # disable the spinner and stream all command output live.
 VERBOSE="${VERBOSE:-0}"
 
+# Repo-owned customizations (composer packages, TYPO3 settings, ...) that
+# survive `ddev add-on get` upgrades. See .setup/project.sh.example.
+if [ -f "/var/www/html/.ddev/.setup/project.sh" ]; then
+    source /var/www/html/.ddev/.setup/project.sh
+fi
+
 # Internal state shared between _progress, _done and _progress_exit_trap.
 SPINNER_PID=0
 PROGRESS_ACTIVE=0
@@ -307,6 +313,12 @@ function create_symlinks_additional_extensions() {
     for dir in Tests/Acceptance/Fixtures/packages/*/; do
         ln -sr "$dir" "$BASE_PATH/packages/$(basename "$dir")"
     done
+
+    for extra_dir in "${FIXTURE_EXTENSION_DIRS[@]}"; do
+        for dir in "$extra_dir"/*/; do
+            [ -d "$dir" ] && ln -sr "$dir" "$BASE_PATH/packages/$(basename "$dir")"
+        done
+    done
 }
 
 # Function to set up Composer for TYPO3 installation.
@@ -319,6 +331,10 @@ function setup_composer() {
     composer config repositories.packages path 'packages/*' --working-dir "$BASE_PATH"
     composer config --no-interaction allow-plugins.typo3/cms-composer-installers true --working-dir "$BASE_PATH"
     composer config --no-interaction allow-plugins.typo3/class-alias-loader true --working-dir "$BASE_PATH"
+
+    for entry in "${COMPOSER_CONFIG[@]}"; do
+        composer config --no-interaction $entry --working-dir "$BASE_PATH"
+    done
 }
 
 # Function to set up TYPO3 configuration.
@@ -337,6 +353,10 @@ function setup_typo3() {
     $TYPO3_BIN configuration:set 'MAIL/transport_smtp_server' 'localhost:1025'
     $TYPO3_BIN configuration:set 'GFX/processor' 'ImageMagick'
     $TYPO3_BIN configuration:set 'GFX/processor_path' '/usr/bin/'
+
+    for entry in "${TYPO3_SETTINGS[@]}"; do
+        eval "$TYPO3_BIN configuration:set $entry"
+    done
 }
 
 # Function to update TYPO3.
@@ -349,11 +369,25 @@ function update_typo3() {
 # Function to install required Composer packages for TYPO3.
 function install_composer_packages() {
   _progress " ├─ Install composer packages"
-    composer req typo3/cms-base-distribution:"^$VERSION" \
-            $PACKAGE_NAME:'*@dev' \
-            test/sitepackage:'*@dev' \
-            helhum/typo3-console:'*' \
-            --no-progress -n -d $BASE_PATH
+    local packages=(
+        "typo3/cms-base-distribution:^$VERSION"
+        "$PACKAGE_NAME:*@dev"
+        "helhum/typo3-console:*"
+    )
+
+    if [ ${#SITEPACKAGE_PACKAGES[@]} -gt 0 ]; then
+        for entry in "${SITEPACKAGE_PACKAGES[@]}"; do
+            eval "packages+=(\"$entry\")"
+        done
+    else
+        packages+=("test/sitepackage:*@dev")
+    fi
+
+    for entry in "${ADDITIONAL_PACKAGES[@]}"; do
+        eval "packages+=(\"$entry\")"
+    done
+
+    composer req "${packages[@]}" --no-progress -n -d $BASE_PATH
   _done
 }
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ If you need more extensions for your setup, you can place them in the `Tests/Acc
 > [!NOTE]
 > You may not need all TYPO3 versions? You can remove the unwanted versions from the `TYPO3_VERSIONS` variable in [.ddev/docker-compose.typo3-setup.yaml](docker-compose.typo3-setup.yaml).
 
+### Project-specific customizations
+
+Copy [.ddev/.setup/project.sh.example](.setup/project.sh.example) to `.ddev/.setup/project.sh` to customize the install without touching `utils.sh` - `project.sh` isn't managed by the add-on, so it survives `ddev add-on get` upgrades. Supported variables:
+
+| Variable | Effect |
+|---|---|
+| `ADDITIONAL_PACKAGES` | Extra composer packages installed alongside the base install |
+| `SITEPACKAGE_PACKAGES` | Replaces the default `test/sitepackage` when set |
+| `COMPOSER_CONFIG` | Extra `composer config` entries |
+| `TYPO3_SETTINGS` | Extra `typo3 configuration:set` calls |
+| `FIXTURE_EXTENSION_DIRS` | Extra directories (besides `Tests/Acceptance/Fixtures/packages`) whose subdirectories get symlinked in as additional extensions |
+
+`$VERSION` in a package constraint expands per version at install time - write it single-quoted (e.g. `'typo3/cms-reports:^$VERSION'`) so it isn't expanded early.
+
 ### Fixtures
 
 During installation, fixture data from `Tests/Acceptance/Fixtures/` is automatically imported. The following types are supported:

--- a/commands/web/.install-11
+++ b/commands/web/.install-11
@@ -9,10 +9,7 @@ set -eo pipefail
 # initial setup tasks before the main installation process begins.
 pre_setup 11
 
-#_progress " ├─ Install additional composer packages"
-#  composer req x/y:'^1.0' \
-#          --no-progress -n -d $BASE_PATH
-#_done
+# Extra composer packages, TYPO3 settings etc. -> .ddev/.setup/project.sh
 
 # Function to perform post-setup tasks.
 # This function is called after the main installation process to finalize the setup.

--- a/commands/web/.install-12
+++ b/commands/web/.install-12
@@ -8,10 +8,7 @@ set -eo pipefail
 # initial setup tasks before the main installation process begins.
 pre_setup 12
 
-#_progress " ├─ Install additional composer packages"
-#  composer req x/y:'^1.0' \
-#          --no-progress -n -d $BASE_PATH
-#_done
+# Extra composer packages, TYPO3 settings etc. -> .ddev/.setup/project.sh
 
 # Function to perform post-setup tasks.
 # This function is called after the main installation process to finalize the setup.

--- a/commands/web/.install-13
+++ b/commands/web/.install-13
@@ -8,10 +8,7 @@ set -eo pipefail
 # initial setup tasks before the main installation process begins.
 pre_setup 13
 
-#_progress " ├─ Install additional composer packages"
-#  composer req x/y:'^1.0' \
-#          --no-progress -n -d $BASE_PATH
-#_done
+# Extra composer packages, TYPO3 settings etc. -> .ddev/.setup/project.sh
 
 # Function to perform post-setup tasks.
 # This function is called after the main installation process to finalize the setup.

--- a/commands/web/.install-14
+++ b/commands/web/.install-14
@@ -8,10 +8,7 @@ set -eo pipefail
 # initial setup tasks before the main installation process begins.
 pre_setup 14
 
-#_progress " ├─ Install additional composer packages"
-#  composer req x/y:'^1.0' \
-#          --no-progress -n -d $BASE_PATH
-#_done
+# Extra composer packages, TYPO3 settings etc. -> .ddev/.setup/project.sh
 
 # Function to perform post-setup tasks.
 # This function is called after the main installation process to finalize the setup.

--- a/install.yaml
+++ b/install.yaml
@@ -10,6 +10,7 @@ pre_install_actions:
 
 project_files:
   - .setup/scripts/utils.sh
+  - .setup/project.sh.example
   - .setup/templates/index.php
   - .setup/Tests/Acceptance/Fixtures/
   - apache/10.conf


### PR DESCRIPTION
## Summary

- Five of seven consumer repos edit `.setup/scripts/utils.sh` directly to add composer packages, TYPO3 settings or composer config - every edit is lost or conflicts on `ddev add-on get`. `.install-<v>` already ships a commented-out scaffold for the composer-package case, but it's a `project_files` entry too, so it has the same problem.

## Changes

- `.setup/project.sh.example` (new) - documents `ADDITIONAL_PACKAGES`, `SITEPACKAGE_PACKAGES`, `COMPOSER_CONFIG`, `TYPO3_SETTINGS`, `FIXTURE_EXTENSION_DIRS`. Ships via `project_files` like any other add-on file (no extra post-install action needed for that - `project_files` copying was already sufficient, simpler than what the issue originally proposed).
- `.setup/scripts/utils.sh` - sources `.ddev/.setup/project.sh` if present (not managed by the add-on, so `ddev add-on get` never touches it), and wires the five variables into `install_composer_packages()`, `setup_composer()`, `setup_typo3()`, `create_symlinks_additional_extensions()`
- `commands/web/.install-11` through `.install-14` - replaced the commented-out `composer req` scaffold with a one-line pointer to `project.sh`, so there's one mechanism for this instead of two
- `README.md` - documents the file and every variable

## A dropped variable

The original proposal included a `COMPOSER_VENDOR` variable for the per-version root package's vendor prefix (`composer init --name=...`). Left it out: this is exactly the "vendor name" customization several consumer repos made locally that upstream already neutralized to `test/` - reintroducing it as a supported customization point would undo that fix.

## Verification

Ran full `ddev install 13` cycles against a scratch project with a real `project.sh` exercising every variable:

- `ADDITIONAL_PACKAGES=('typo3/cms-reports:^$VERSION')` - package installed, `$VERSION` correctly expanded per-version, not at source time
- `COMPOSER_CONFIG=('allow-plugins.typo3/testing-framework true')` - `composer config allow-plugins.typo3/testing-framework` returns `true`
- `TYPO3_SETTINGS` with `"MAIL/defaultMailFromAddress no-reply@\${DDEV_SITENAME}.ddev.site"` - resolved to `no-reply@wt-scratch.ddev.site` (deferred expansion at use time, not source time) - and a plain quoted value (`MAIL/defaultMailFromName "My Project"`) preserved correctly
- `FIXTURE_EXTENSION_DIRS=('Tests/Functional/Fixtures/Extensions')` - the extra extension there was correctly symlinked into `packages/`
- Removed `project.sh` entirely and reinstalled - behavior identical to before this change (only `sitepackage` + the main extension symlinked)

Closes #31