### PR TITLE
feat: hook scripts for non-declarative install steps

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -209,6 +209,7 @@ function pre_setup() {
   _done
   install_start
   install_composer_packages
+  run_hook "post-composer"
 }
 
 # Function to perform post-setup tasks for TYPO3 installation.
@@ -233,6 +234,8 @@ function post_setup() {
     fi
   _done
 
+  run_hook "post-typo3-setup"
+
   _progress " ├─ Import data"
     import_xml_data
     import_sql_data
@@ -242,7 +245,33 @@ function post_setup() {
   _progress " ├─ Update TYPO3"
     update_typo3
   _done
+
+  run_hook "post-install"
+
   printf " └─ \033[33mTYPO3 $VERSION setup completed!\033[0m Open in your browser: https://$VERSION.${EXTENSION_NAME}.ddev.site\n"
+}
+
+# Function to run an optional, repo-owned install hook if it exists.
+# Hooks live at .ddev/.setup/hooks/<name>.sh and are sourced (not executed as
+# a subprocess) so they have access to $VERSION, $BASE_PATH, $TYPO3_BIN,
+# $DATABASE, $EXTENSION_KEY and the message/_progress/_done helpers. Because
+# they are sourced into a caller running under `set -e`, a failing command in
+# a hook aborts the install and its captured output is replayed - unlike the
+# best-effort Tests/Acceptance/Fixtures/*.sh scripts, a hook failure is not
+# swallowed.
+#
+# Supported hook names: pre-install, post-composer, post-typo3-setup, post-install.
+function run_hook() {
+    local hook_name="$1"
+    local hook_file="/var/www/html/.ddev/.setup/hooks/${hook_name}.sh"
+
+    if [ ! -f "$hook_file" ]; then
+        return 0
+    fi
+
+    _progress " ├─ Hook: $hook_name"
+      source "$hook_file"
+    _done
 }
 
 # Function to display an introductory message for the TYPO3 version.
@@ -260,6 +289,8 @@ function intro_typo3() {
 # sets up the environment, creates symlinks for the main and additional extensions,
 # and sets up Composer for the TYPO3 installation.
 function install_start() {
+    run_hook "pre-install"
+
     rm -rf /var/www/html/.Build/$VERSION/*
     _progress " ├─ Setup environment"
       setup_environment

--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ Copy [.ddev/.setup/project.sh.example](.setup/project.sh.example) to `.ddev/.set
 
 `$VERSION` in a package constraint expands per version at install time - write it single-quoted (e.g. `'typo3/cms-reports:^$VERSION'`) so it isn't expanded early.
 
+### Install hooks
+
+For install steps that don't fit a variable in `project.sh`, add a script at `.ddev/.setup/hooks/<name>.sh` - it's sourced automatically if present, so it has access to `$VERSION`, `$BASE_PATH`, `$TYPO3_BIN`, `$DATABASE`, `$EXTENSION_KEY` and the `message`/`_progress`/`_done` helpers. Unlike the best-effort `Tests/Acceptance/Fixtures/*.sh` scripts, a failing command in a hook aborts the install with its output shown, not silently swallowed.
+
+| Hook | Runs |
+|---|---|
+| `pre-install` | Before the environment is set up (`$TYPO3_BIN`/`$DATABASE` are not yet available at this point) |
+| `post-composer` | After the base composer packages are installed |
+| `post-typo3-setup` | After TYPO3 itself is set up, before fixture import |
+| `post-install` | Last, after fixtures, site configs and the schema update |
+
 ### Fixtures
 
 During installation, fixture data from `Tests/Acceptance/Fixtures/` is automatically imported. The following types are supported:


### PR DESCRIPTION
## Summary

- Not everything fits a variable list (#31 covers the declarative 90%). `typo3-pagetree-facets` needs to run `pagetree-facets:seed-demo-content` after the schema exists, guard against the command being absent, and print a summary - real logic, not a value.

## Changes

- `.setup/scripts/utils.sh` - new `run_hook()`, sourcing `.ddev/.setup/hooks/<name>.sh` if present, wrapped in the existing `_progress`/`_done` machinery so failures are reported with captured output (not swallowed) for free - reused the existing infrastructure instead of building new failure-reporting logic
- Four call sites: `pre-install` (in `install_start()`, before environment setup), `post-composer` (in `pre_setup()`, after composer packages), `post-typo3-setup` and `post-install` (in `post_setup()`, bracketing fixture import)
- `README.md` - documents the hook names, run order, and available variables/helpers

Complements #31: declarative variables there, arbitrary shell here.

## Verification

Deployed to the scratch project with all four hooks writing a marker line:

```
├─ Hook: pre-install...    HOOK pre-install ran (VERSION=13 BASE_PATH=/var/www/html/.Build/13)
├─ Hook: post-composer...  HOOK post-composer ran (DATABASE=database_13 EXTENSION_KEY=wt_scratch)
├─ Hook: post-typo3-setup... HOOK post-typo3-setup ran
├─ Hook: post-install...   HOOK post-install ran
```

All four fired in order with the documented variables populated. Then made `post-composer.sh` `exit 1`: the install aborted (`Failed to run install 13 -v: exit status 1`) with the hook's own output (`about to fail on purpose`) shown, not swallowed. Removed the hooks directory entirely and reinstalled - behavior identical to before.

Stacked on #49.

Closes #32