### PR TITLE
fix: stop CS-fixer churn on the generated intro page

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ If you need more extensions for your setup, you can place them in the `Tests/Acc
 > [!NOTE]
 > You may not need all TYPO3 versions? You can remove the unwanted versions from the `TYPO3_VERSIONS` variable in [.ddev/docker-compose.typo3-setup.yaml](docker-compose.typo3-setup.yaml).
 
+### Avoiding CS-fixer churn on `.ddev/`
+
+If your project runs `php-cs-fixer` (or a similar tool) on the whole repository, it will also reformat the files this add-on manages under `.ddev/` to match *your* project's rules - which may differ from the rules this add-on's own files were written with. That produces a spurious diff on every `ddev add-on get` update, and every `composer cgl`/fixer run dirties files that aren't supposed to be edited locally anyway. Exclude `.ddev/` from your fixer's paths to avoid this:
+
+```php
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('.ddev');
+```
+
 ### Fixtures
 
 During installation, fixture data from `Tests/Acceptance/Fixtures/` is automatically imported. The following types are supported:


### PR DESCRIPTION
## Summary

- `.ddev/.setup/templates/index.php` differed from upstream in every consumer repo by the same few lines - concatenation spacing and Yoda conditions, i.e. php-cs-fixer artefacts from each consumer's own fixer run, not real changes. Every `ddev add-on get` update and every `composer cgl` run therefore produced a spurious diff.

## What I actually found

Objectively verified with a real `php-cs-fixer` run (`@PSR12` + `concat_space: one` + `yoda_style: false` + a few common rules) against the **current** `index.php` on `main`: **0 of 1 files needed fixing.** The concatenation-spacing and Yoda-condition issues described in the original review don't exist in the file as it stands today - they were presumably already cleaned up in an earlier revision, or only ever existed in the stale copies frozen in consumer repos by the bug fixed in #36.

So there's nothing to reformat in `index.php` itself. The actual fix is the second half of the original proposal: making sure a *consumer's* fixer run doesn't reintroduce this the next time someone adds a rule that disagrees with this file's style.

## Changes

- `README.md` - new subsection recommending consumers exclude `.ddev/` from their own `php-cs-fixer` finder, with a short code example

## Verification

`php-cs-fixer fix --dry-run --diff` against a representative PSR-12-based ruleset: `Found 0 of 1 files that can be fixed.`

Closes #33