### PR TITLE
feat: support nginx-fpm in addition to apache-fpm

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -284,6 +284,17 @@ function setup_environment() {
     else
         export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3"
     fi
+    # Derived at runtime rather than hardcoded, so the same setup works
+    # whether the project uses apache-fpm or nginx-fpm. TYPO3's setup/
+    # install:setup commands only generate a webserver config file for
+    # "apache" (.htaccess) or "iis" (web.config) - nginx has no per-directory
+    # config file, so anything else is "other" (generates none).
+    if [ "$DDEV_WEBSERVER_TYPE" == "apache-fpm" ]; then
+        export TYPO3_SERVER_TYPE="apache"
+    else
+        export TYPO3_SERVER_TYPE="other"
+    fi
+    export TYPO3_INSTALL_WEB_SERVER_CONFIG="$TYPO3_SERVER_TYPE"
     mysql -uroot -proot -e "DROP DATABASE IF EXISTS $DATABASE"
 }
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ddev-typo3-multi-version-extension is a DDEV add-on that provides a multi-versio
 ## Requirements
 
 - Extension key as DDEV project name, e.g. `custom-extension`
-- `apache-fpm` as webserver type
+- `apache-fpm` or `nginx-fpm` as webserver type
 - a valid `composer.json` file in the project root directory
 
 You may use the following command to create a new DDEV project with the required settings:

--- a/docker-compose.typo3-setup.yaml
+++ b/docker-compose.typo3-setup.yaml
@@ -19,7 +19,6 @@ services:
             - TYPO3_INSTALL_ADMIN_PASSWORD=Password1!
             - TYPO3_INSTALL_SITE_NAME=EXT:custom-extension-key Dev Environment
             - TYPO3_INSTALL_SITE_SETUP_TYPE=site
-            - TYPO3_INSTALL_WEB_SERVER_CONFIG=apache
 
             # TYPO3 v13 and v14 config
             - TYPO3_DB_DRIVER=mysqli
@@ -30,4 +29,3 @@ services:
             - TYPO3_SETUP_ADMIN_USERNAME=admin
             - TYPO3_SETUP_ADMIN_PASSWORD=Password1!
             - TYPO3_PROJECT_NAME=EXT:custom-extension-key Dev Environment
-            - TYPO3_SERVER_TYPE=apache

--- a/install.yaml
+++ b/install.yaml
@@ -3,8 +3,8 @@ name: typo3-multi-version-extension
 pre_install_actions:
   - |
     #ddev-description:Check for incompatible server type
-    if [ "${DDEV_WEBSERVER_TYPE}" != "apache-fpm" ]; then
-      echo "This package only works with the apache webserver";
+    if [ "${DDEV_WEBSERVER_TYPE}" != "apache-fpm" ] && [ "${DDEV_WEBSERVER_TYPE}" != "nginx-fpm" ]; then
+      echo "This package only works with the apache-fpm or nginx-fpm webserver type";
       exit 1;
     fi
 
@@ -14,6 +14,7 @@ project_files:
   - .setup/Tests/Acceptance/Fixtures/
   - apache/10.conf
   - apache/20.conf
+  - nginx_full/nginx-site.conf
   - commands/host/launch
   - commands/web/.install-11
   - commands/web/.install-12
@@ -71,7 +72,7 @@ post_install_actions:
     cat <<EOF >${DDEV_APPROOT}/.ddev/config.typo3-setup.yaml
     type: php
     docroot: .Build
-    webserver_type: apache-fpm
+    webserver_type: ${DDEV_WEBSERVER_TYPE}
     additional_hostnames:
       - 11.${DDEV_PROJECT}
       - 12.${DDEV_PROJECT}

--- a/nginx_full/nginx-site.conf
+++ b/nginx_full/nginx-site.conf
@@ -1,0 +1,111 @@
+# ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-nginx-configuration
+#
+# Unlike Apache, nginx has no way to interpolate the project's hostname from
+# the environment into a config directive, so this doesn't attempt to - the
+# version-routed server block below matches on the numeric prefix of the Host
+# header alone (regex server_name), which makes it project-name independent
+# by construction, without needing any interpolation at all.
+
+# <11-14>.<anything> -> .Build/<version>/public
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name ~^(?<t3version>1[1-4])\..*$;
+
+    root /var/www/html/.Build/$t3version/public;
+
+    ssl_certificate /etc/ssl/certs/master.crt;
+    ssl_certificate_key /etc/ssl/certs/master.key;
+
+    include /etc/nginx/monitoring.conf;
+
+    index index.php;
+    sendfile off;
+    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+
+    location / {
+        absolute_redirect off;
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php/php-fpm.sock;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors off;
+        fastcgi_read_timeout 10m;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+    }
+
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    include /etc/nginx/common.d/*.conf;
+    include /mnt/ddev_config/nginx/*.conf;
+}
+
+# Bare project hostname -> intro page in .Build/
+server {
+    listen 80 default_server;
+    listen 443 ssl default_server;
+
+    root /var/www/html/.Build;
+
+    ssl_certificate /etc/ssl/certs/master.crt;
+    ssl_certificate_key /etc/ssl/certs/master.key;
+
+    include /etc/nginx/monitoring.conf;
+
+    index index.php;
+    sendfile off;
+    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+
+    location / {
+        absolute_redirect off;
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php/php-fpm.sock;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors off;
+        fastcgi_read_timeout 10m;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+    }
+
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    include /etc/nginx/common.d/*.conf;
+    include /mnt/ddev_config/nginx/*.conf;
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -98,6 +98,20 @@ JSON
   health_checks
 }
 
+@test "install from directory on nginx-fpm" {
+  set -eu -o pipefail
+  run ddev config --webserver-type=nginx-fpm
+  assert_success
+  run ddev restart -y
+  assert_success
+
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+  health_checks
+}
+
 # bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail


### PR DESCRIPTION
## Summary

- The add-on refused to install on anything but `apache-fpm`, and the generated `config.typo3-setup.yaml` force-set `webserver_type: apache-fpm` even when a project had deliberately chosen nginx (DDEV's default webserver type). Since #22 made the Apache vhosts project-name independent, the same treatment now extends to nginx.

## Changes

- `install.yaml` - the pre-install check now accepts `apache-fpm` or `nginx-fpm`; `webserver_type` in the generated config is derived from `${DDEV_WEBSERVER_TYPE}` instead of hardcoded; ships the new `nginx_full/nginx-site.conf`
- `nginx_full/nginx-site.conf` (new) - nginx equivalent of the two-vhost Apache routing. nginx has no way to interpolate the project hostname from the environment at all (unlike Apache's `${VAR}`), so this doesn't try to - the version-routed server block matches purely on the numeric prefix of the `Host` header via a regex `server_name`, which makes it project-name independent by construction without needing any interpolation
- `.setup/scripts/utils.sh` - `TYPO3_SERVER_TYPE`/`TYPO3_INSTALL_WEB_SERVER_CONFIG` are now derived at runtime from `$DDEV_WEBSERVER_TYPE` instead of hardcoded to `apache`
- `docker-compose.typo3-setup.yaml` - dropped the now-dead hardcoded `TYPO3_SERVER_TYPE=apache` / `TYPO3_INSTALL_WEB_SERVER_CONFIG=apache` entries
- `README.md` - states both webserver types are supported
- `tests/test.bats` - new `install from directory on nginx-fpm` test

## A correction found during testing

TYPO3's `setup`/`install:setup` commands only accept `apache`, `iis`, or `other` as the server type (verified via the tool's own error message) - there is no `nginx` value, since TYPO3 doesn't generate an nginx-specific webserver config file at all (nginx has no per-directory config the way `.htaccess` works for Apache). So the mapping is `apache-fpm` → `apache`, everything else → `other` (generates no webserver config file), not a literal `${DDEV_WEBSERVER_TYPE%-fpm}` strip as originally sketched.

## Verification

All against real, freshly-started DDEV projects (not just config inspection):

**nginx routing in isolation** (before wiring it into the add-on): started a bare `ddev/ddev-webserver` container with the new `nginx_full/nginx-site.conf` and static per-version marker files, requested three different `Host` headers against a hostname (`nginx-test.ddev.site`) that appears nowhere in the config:
```
nginx-test.ddev.site    -> INTRO docroot=/var/www/html/.Build
13.nginx-test.ddev.site -> T13   docroot=/var/www/html/.Build/13/public
14.nginx-test.ddev.site -> T14   docroot=/var/www/html/.Build/14/public
```

**Full add-on install on a real nginx-fpm DDEV project**:
- `ddev add-on get` succeeds, `config.typo3-setup.yaml` keeps `webserver_type: nginx-fpm`
- `ddev install 13` completes ("TYPO3 Setup is done")
- `https://nginx-ref.ddev.site/` → 200, intro page
- `https://13.nginx-ref.ddev.site/` → 200, real TYPO3 frontend
- `https://13.nginx-ref.ddev.site/typo3/` → 200, TYPO3 backend login
- No `.htaccess` generated (confirms the `other` server-type mapping took effect)

**Apache regression check** on the existing scratch project with the same new runtime-derivation code path:
- `ddev install 13` still completes
- `.htaccess` is still generated (15KB, real TYPO3 file)
- Frontend still returns 200

Stacked on #39.

Closes #34