### PR TITLE
feat: default installed instances to TYPO3_CONTEXT=Development

### DIFF
--- a/.setup/scripts/utils.sh
+++ b/.setup/scripts/utils.sh
@@ -281,6 +281,13 @@ function setup_environment() {
     else
         export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3"
     fi
+    # Default to Development for a throwaway dev environment. Left as a
+    # fallback (not hardcoded here or in docker-compose.typo3-setup.yaml) so
+    # a project-level `ddev config --web-environment-add=TYPO3_CONTEXT=...`
+    # can still override it - add-on compose files are layered on top of
+    # DDEV's own config-derived one, so a hardcoded value here would always
+    # win over that override.
+    export TYPO3_CONTEXT="${TYPO3_CONTEXT:-Development}"
     mysql -uroot -proot -e "DROP DATABASE IF EXISTS $DATABASE"
 }
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ If you need more extensions for your setup, you can place them in the `Tests/Acc
 > [!NOTE]
 > You may not need all TYPO3 versions? You can remove the unwanted versions from the `TYPO3_VERSIONS` variable in [.ddev/docker-compose.typo3-setup.yaml](docker-compose.typo3-setup.yaml).
 
+Every installed instance runs with `TYPO3_CONTEXT=Development`. Override it per project with `ddev config --web-environment-add="TYPO3_CONTEXT=Production"` (followed by `ddev restart`) if you need production-context parity.
+
 ### Fixtures
 
 During installation, fixture data from `Tests/Acceptance/Fixtures/` is automatically imported. The following types are supported:


### PR DESCRIPTION
## Summary

- None of the installed TYPO3 instances set `TYPO3_CONTEXT`, so TYPO3 defaults to `Production`. That affects more than the individual dev-mode settings `setup_typo3()` already configures by hand (`BE/debug`, `SYS/displayErrors`, ...) - it also changes caching backends and error handler behavior. For a disposable dev environment, `Development` is the more consistent default.

## Changes

- `.setup/scripts/utils.sh` - `setup_environment()` now exports `TYPO3_CONTEXT="${TYPO3_CONTEXT:-Development}"`
- `README.md` - documents the default and the override path

## Where the value is set, and why not docker-compose

Tried setting it as a hardcoded env var in `docker-compose.typo3-setup.yaml` first. That doesn't compose correctly with DDEV's own per-project override mechanism (`ddev config --web-environment-add=...`): add-on-provided compose files are layered on top of DDEV's own config-derived one, so a value hardcoded there always wins regardless of what a project's `web_environment` sets - verified this dead end live (`ddev debug compose-config` showed the add-on's value winning even with an override configured). Using a bash fallback (`${TYPO3_CONTEXT:-Development}`) inside the install script instead means we only supply a default when nothing else already set it, so the override path actually works.

## Verification

- Without any override: `TYPO3_CONTEXT` resolves to `Development` during install
- With `ddev config --web-environment-add="TYPO3_CONTEXT=Production"` + `ddev restart`: resolves to `Production`

Closes #55