### PR TITLE
docs: document the router 404 gotcha when starting a new worktree project

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ ddev install all
 
 `ddev worktree-init` regenerates this checkout's router hostnames so they don't collide with the primary checkout's; `.Build/` is gitignored, so every worktree needs its own `ddev install`.
 
+> [!NOTE]
+> A bare `404 page not found` right after `ddev restart` is the ddev **router**, not TYPO3 - registering a new project while others are already running can leave the router without a route for it until the project is restarted once more. Run `ddev restart` again if you see it.
+
 ### Resource expectations
 
 Each worktree runs its own `web` and `db` container, plus roughly one full TYPO3 distribution per configured version under `.Build/`. Running several worktrees at once multiplies both. `ddev poweroff` stops *all* DDEV projects, not just the current one - worth knowing if several worktrees (or agents) are meant to keep running in parallel.

--- a/commands/host/worktree-init
+++ b/commands/host/worktree-init
@@ -29,3 +29,4 @@ override_file=".ddev/config.zz-worktree.local.yaml"
 
 echo "Wrote ${override_file} with hostnames for project '${DDEV_PROJECT}' (versions: ${typo3_versions})."
 echo "Run 'ddev restart' to apply it, then 'ddev install all' to install the TYPO3 instances."
+echo "If you get a bare '404 page not found' right after restarting, that's the ddev router not yet having a route for this new project - run 'ddev restart' once more."


### PR DESCRIPTION
## Summary

- Each git worktree gets its own DDEV project registered on the same shared ddev-router. Registering a new project while others are already running can leave the router without a route for it until the project restarts a second time - in that state, every request answers with a bare `404 page not found` from the router itself, not from TYPO3 or the webserver inside the container. `ddev worktree-init` → `ddev restart` is exactly that "register a new project while others run" scenario.

## Changes

- `commands/host/worktree-init` - prints a hint about the router 404 symptom and the fix (restart again) as part of its own next-steps output, not just buried in the README
- `README.md` - documents the same symptom as a note under the per-worktree setup steps

No automatic probe/retry - kept this documentation-only, since a script silently retrying `ddev restart` on its own would hide a possibly-different real failure behind a generic retry.

Closes #53