### PR TITLE
feat: add a worktree-remove counterpart to worktree-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ ddev install all
 
 Each worktree runs its own `web` and `db` container, plus roughly one full TYPO3 distribution per configured version under `.Build/`. Running several worktrees at once multiplies both. `ddev poweroff` stops *all* DDEV projects, not just the current one - worth knowing if several worktrees (or agents) are meant to keep running in parallel.
 
+### Removing a worktree
+
+From inside the worktree, `ddev worktree-remove` unregisters its DDEV project and drops its database, images and volumes, then prints the `git worktree remove` / `git branch -D` commands to run from your **primary** checkout (a worktree cannot remove itself while you're inside it).
+
 ### Upgrading an existing project
 
 If you installed this add-on before worktree support was added, re-run the installation command to pick up the fixes:

--- a/commands/host/worktree-remove
+++ b/commands/host/worktree-remove
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+## #ddev-generated
+## Description: Tear down this worktree's DDEV project (unregister, drop database/images/volumes). Run the printed git commands from the primary checkout afterwards to remove the worktree itself.
+## Usage: worktree-remove
+## Example: "ddev worktree-remove"
+
+set -eo pipefail
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Not a git repository - nothing to do."
+    exit 1
+fi
+
+worktree_path="$(pwd)"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+echo "Deleting DDEV project '${DDEV_PROJECT}' (unregister + drop database, images, volumes)..."
+ddev delete -Oy
+
+echo ""
+echo "DDEV project removed. This command cannot remove the worktree itself while running"
+echo "from inside it - from your PRIMARY checkout, run:"
+echo ""
+echo "  git worktree remove --force '${worktree_path}'"
+echo "  git branch -D '${branch}'"

--- a/install.yaml
+++ b/install.yaml
@@ -16,6 +16,7 @@ project_files:
   - apache/20.conf
   - commands/host/launch
   - commands/host/worktree-init
+  - commands/host/worktree-remove
   - commands/web/.install-11
   - commands/web/.install-12
   - commands/web/.install-13


### PR DESCRIPTION
## Summary

- `ddev worktree-init` has no counterpart for tearing a worktree back down. Removing one today means manually running `ddev delete -Oy`, then `git worktree remove`, then cleaning up the branch - easy to do incompletely (e.g. forgetting to unregister the DDEV project, leaving its database/volumes around).

## Changes

- `commands/host/worktree-remove` (new) - runs `ddev delete -Oy` for the current project, then prints the exact git commands to run from the primary checkout to remove the worktree and its branch. It can't do the git side itself: removing a worktree must run from a location that isn't the worktree being removed.
- `README.md` - documents it under a new "Removing a worktree" section

## Verification

Ran it against a real throwaway git-worktree-style project (own repo, own branch, own DDEV project, not started):

```
Deleting DDEV project 'wtr-test-b' (unregister + drop database, images, volumes)...
Project wtr-test-b was deleted. Your code and configuration are unchanged.

DDEV project removed. This command cannot remove the worktree itself while running
from inside it - from your PRIMARY checkout, run the two printed commands.
```

Confirmed the project no longer appears in `ddev list` afterwards, and both printed commands reference the correct absolute path and branch name.

Stacked on #58.

Closes #54
