### PR TITLE
docs: document that worktrees only see committed project.sh/hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ ddev install all
 > [!NOTE]
 > A bare `404 page not found` right after `ddev restart` is the ddev **router**, not TYPO3 - registering a new project while others are already running can leave the router without a route for it until the project is restarted once more. Run `ddev restart` again if you see it.
 
+A worktree only ever contains committed content. If a repo-owned customization file such as `.ddev/.setup/project.sh` or a script under `.ddev/.setup/hooks/` isn't committed, a new worktree simply won't have it - no error, the customization just doesn't apply.
+
 ### Resource expectations
 
 Each worktree runs its own `web` and `db` container, plus roughly one full TYPO3 distribution per configured version under `.Build/`. Running several worktrees at once multiplies both. `ddev poweroff` stops *all* DDEV projects, not just the current one - worth knowing if several worktrees (or agents) are meant to keep running in parallel.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ ddev install all
 > [!NOTE]
 > A bare `404 page not found` right after `ddev restart` is the ddev **router**, not TYPO3 - registering a new project while others are already running can leave the router without a route for it until the project is restarted once more. Run `ddev restart` again if you see it.
 
-A worktree only ever contains committed content. If a repo-owned customization file such as `.ddev/.setup/project.sh` or a script under `.ddev/.setup/hooks/` isn't committed, a new worktree simply won't have it - no error, the customization just doesn't apply.
+A new worktree checkout initially contains only committed repository content. If a repo-owned customization file such as `.ddev/.setup/project.sh` or a script under `.ddev/.setup/hooks/` isn't committed, a new worktree simply won't have it - no error, the customization just doesn't apply.
 
 ### Resource expectations
 


### PR DESCRIPTION
## Summary

- `.ddev/.setup/project.sh` and scripts under `.ddev/.setup/hooks/` are explicitly designed to be repo-owned customizations that survive add-on upgrades - but if a repo keeps either uncommitted (a plausible choice, since they can contain environment- or machine-specific tweaks nobody wants to force on the whole team), a fresh worktree silently doesn't have them. The customization just doesn't apply, with no error and no obvious reason why.

## Changes

- `README.md` - documents in the Git Worktree Support section that a worktree only sees committed content, called out specifically for these two customization points

No code change - this is a documentation gap, not a behavior gap. Auto-copying uncommitted local files into a new worktree would raise its own consent/security questions and isn't proposed here.

Closes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that newly created worktrees do not include uncommitted repository customizations.
  * Noted that these customizations are simply not applied and do not produce errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->