### PR TITLE
docs: restructure README into a Tier B documentation set

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Exclude files from releases/tarballs
+docs/ export-ignore
 tests/ export-ignore
 .github/ export-ignore
 .gitattributes export-ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+## Local setup
+
+This add-on is developed against a real DDEV project, since it has no
+meaningful behaviour outside one.
+
+```shell
+mkdir my-test-extension && cd my-test-extension
+composer init --name=vendor/my-test-extension --type=typo3-cms-extension --no-interaction
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --project-name=my-test-extension
+ddev add-on get /path/to/your/ddev-typo3-multi-version-extension/checkout
+ddev restart
+ddev install all
+```
+
+`ddev add-on get` accepts a local path, so changes in your checkout are picked
+up on the next `ddev add-on get` / `ddev restart` without publishing anything.
+
+## Tests
+
+Automated tests use [bats-core](https://bats-core.readthedocs.io/), run
+locally from the repository root:
+
+```shell
+bats ./tests/test.bats
+# Exclude release tests:
+bats ./tests/test.bats --filter-tags '!release'
+# Exclude the heavy end-to-end install test:
+bats ./tests/test.bats --filter-tags '!install'
+```
+
+CI runs the same suite via `ddev/github-action-add-on-test` on every pull
+request, against both the stable and `HEAD` DDEV releases.
+
+`tests/MANUAL_TESTING_CHECKLIST.md` tracks exploratory coverage against a real
+extension that the automated suite does not reach - update it alongside a
+change when it touches behaviour the checklist exercises.
+
+## Commit messages
+
+Conventional commits: `<type>: <description>` (`feat`, `fix`, `refactor`,
+`docs`, `test`, `chore`, `ci`), describing the change rather than the ticket
+that triggered it.
+
+## Files with a `#ddev-generated` marker
+
+Anything shipped under `.ddev/` with a `#ddev-generated` marker is overwritten
+on every `ddev add-on get` update - see
+[Updating](README.md#updating). Keep that in mind when editing
+`commands/`, `.setup/scripts/`, `.setup/templates/` or the compose files: a
+change there ships to every consumer's project on their next update.
+
+## Pull requests
+
+Open the PR against `main`. CI must pass (`tests.yml`) before merge.

--- a/README.md
+++ b/README.md
@@ -1,319 +1,80 @@
-<div align="center">
-
-ddev-typo3-multi-version-extension
-===============================
+# ddev-typo3-multi-version-extension
 
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![tests](https://github.com/konradmichalik/ddev-typo3-multi-version-extension/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/konradmichalik/ddev-typo3-multi-version-extension/actions/workflows/tests.yml?query=branch%3Amain)
 [![last commit](https://img.shields.io/github/last-commit/konradmichalik/ddev-typo3-multi-version-extension)](https://github.com/konradmichalik/ddev-typo3-multi-version-extension/commits)
 [![release](https://img.shields.io/github/v/release/konradmichalik/ddev-typo3-multi-version-extension)](https://github.com/konradmichalik/ddev-typo3-multi-version-extension/releases/latest)
-</div>
 
-## What is `ddev-typo3-multi-version-extension`?
+Testing a TYPO3 extension against several major versions normally means either
+juggling one DDEV project per version or repeatedly swapping the `typo3/cms-*`
+constraint in a single `composer.json`. This add-on runs TYPO3 12, 13 and 14 as
+sibling instances inside one DDEV project, each with its own hostname and
+database, all symlinking the same extension checkout - so a change is visible
+on every version at once, without reinstalling anything.
 
-ddev-typo3-multi-version-extension is a DDEV add-on that provides a multi-version TYPO3 environment. With this feature, it is possible to develop and test your extension with different TYPO3 versions at the same time.
+## ✨ Features
 
-## Support
-
-- TYPO3 11.5
-- TYPO3 12.4
-- TYPO3 13.4
-- TYPO3 14.3
-
-## Requirements
-
-- Extension key as DDEV project name, e.g. `custom-extension`
-- `apache-fpm` or `nginx-fpm` as webserver type
-- a valid `composer.json` file in the project root directory
-
-You may use the following command to create a new DDEV project with the required settings:
-
-```shell
-ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --project-name=custom-extension
-```
+- [**Parallel TYPO3 instances**](docs/commands.md): TYPO3 12, 13 and 14 run side by side by default under `.Build/<version>/`; TYPO3 11 can be re-enabled (see [Configuration](docs/configuration.md))
+- [**Classic (non-Composer) mode**](docs/classic-mode.md): rebuild any version as a TER-style install to catch bugs that only surface outside Composer autoloading
+- [**Fixture import**](docs/configuration.md#fixtures): XML exports, raw SQL, site configurations and shell scripts are imported automatically on every install
+- [**Demo content profiles**](docs/installation.md#--demoprofile): populate an instance with `typo3/cms-introduction` or `bk2k/bootstrap-package` instead of a blank page
+- [**Install hooks and `project.sh`**](docs/configuration.md): add composer packages, TYPO3 settings and custom install steps without touching add-on-managed files
+- [**Git worktree support**](docs/git-worktrees.md): run several checkouts of the same repository side by side without hostname collisions
 
 ## 🔥 Installation
 
-Install the add-on with the following command:
+> [!IMPORTANT]
+> Requires a DDEV project with the project name set to your extension key (e.g.
+> `custom-extension`), `apache-fpm` or `nginx-fpm` as the webserver type, and a
+> valid `composer.json` in the project root. Git worktree support additionally
+> requires DDEV `>= v1.24.10`.
 
 ```shell
-ddev add-on get konradmichalik/ddev-typo3-multi-version-extension && ddev restart
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --project-name=custom-extension
+ddev add-on get konradmichalik/ddev-typo3-multi-version-extension
+ddev restart
 ```
-
-After the installation, you can use the following command to open the intro page:
-
-```shell
-ddev launch
-```
-
-To install TYPO3 instances, use the following command:
-
-```shell
-ddev install all
-# or for a specific version
-ddev install 12
-```
-
-You can also rebuild a single version as a Composer-free (TER-style) instance with
-`ddev install 13 --classic` — see [🧩 Classic mode](#-classic-mode-non-composer).
-
-![Screencast](./images/screencast.gif)
-
-For a detailed console output, use the following command:
-
-```shell
-ddev install 12 -v
-````
 
 ### Updating
 
 Run `ddev add-on get konradmichalik/ddev-typo3-multi-version-extension && ddev restart` again to pick up add-on updates in an existing project.
 
-Files that ship with a `#ddev-generated` marker (e.g. `.ddev/.setup/scripts/utils.sh`, `.ddev/.setup/templates/index.php`, the `commands/web/*` wrappers) are overwritten on every update. If you need to customize one of them, remove that marker line from your project's copy — DDEV will then leave the file alone on future updates.
+Files that ship with a `#ddev-generated` marker (e.g. `.ddev/.setup/scripts/utils.sh`, `.ddev/.setup/templates/index.php`, the `commands/web/*` wrappers) are overwritten on every update. If you need to customize one of them, remove that marker line from your project's copy - DDEV will then leave the file alone on future updates.
 
-## ⚙ Configuration
-
-By default, a blank TYPO3 instance will be installed for each version. They are only two extensions installed:
-
-- your **main extension** from the project root (symlinked)
-- a demo **sitepackage extension** in from the `Tests/Acceptance/Fixtures/packages` directory
-
-Use this sitepackage to test the features of your main extension. You can adjust it to your needs in `Tests/Acceptance/Fixtures/packages/sitepackage/`.
-
-If you need more extensions for your setup, you can place them in the `Tests/Acceptance/Fixtures/packages` directory or adjust the `ddev install` command. Within the e.g. the [.install-12](commands/web/.install-12) file, you can adjust the `composer require` command to fit your needs.
-
-> [!NOTE]
-> You may not need all TYPO3 versions? You can remove the unwanted versions from the `TYPO3_VERSIONS` variable in [.ddev/docker-compose.typo3-setup.yaml](docker-compose.typo3-setup.yaml).
-
-Items from your main extension's root directory are symlinked into the TYPO3 instance, except the ones listed in the `SYMLINK_EXCLUSIONS` variable in [.ddev/docker-compose.typo3-setup.yaml](docker-compose.typo3-setup.yaml). It defaults to `Documentation Documentation-GENERATED-temp var vendor public`, so a local `vendor/` or `public/` directory in your extension repository is not linked into the instance's own composer/web-root structure.
-
-### Demo content
-
-Pass `--demo` to `ddev install` to populate the instance with a demo site instead of a single blank page. The demo step always drops and rebuilds the instance rather than layering onto an existing one, so re-running it is deterministic.
+## 🚀 Quick start
 
 ```shell
-ddev install 13 --demo
-ddev install 13 --demo=bootstrap
-ddev install all --demo
-```
-
-Profiles:
-
-| Profile | Result |
-|---|---|
-| `introduction` (default) | Installs [`typo3/cms-introduction`](https://extensions.typo3.org/extension/introduction) and removes the generated `main` site, since the Introduction Package brings its own. **Not available on TYPO3 14** - no released version supports it yet, so `--demo`/`--demo=introduction` automatically falls back to the `bootstrap` profile on 14 with a message. |
-| `bootstrap` | Installs [`bk2k/bootstrap-package`](https://packagist.org/packages/bk2k/bootstrap-package) only - a themed but otherwise empty site. Works on every supported version. |
-| `custom` | Installs no demo package; relies entirely on your own `Tests/Acceptance/Fixtures/` fixtures (see below). |
-
-### Project-specific customizations
-
-Copy [.ddev/.setup/project.sh.example](.setup/project.sh.example) to `.ddev/.setup/project.sh` to customize the install without touching `utils.sh` - `project.sh` isn't managed by the add-on, so it survives `ddev add-on get` upgrades. Supported variables:
-
-| Variable | Effect |
-|---|---|
-| `ADDITIONAL_PACKAGES` | Extra composer packages installed alongside the base install |
-| `SITEPACKAGE_PACKAGES` | Replaces the default `test/sitepackage` when set |
-| `COMPOSER_CONFIG` | Extra `composer config` entries |
-| `TYPO3_SETTINGS` | Extra `typo3 configuration:set` calls |
-| `FIXTURE_EXTENSION_DIRS` | Extra directories (besides `Tests/Acceptance/Fixtures/packages`) whose subdirectories get symlinked into Composer's local package repository |
-
-`$VERSION` in a package constraint expands per version at install time - write it single-quoted (e.g. `'typo3/cms-reports:^$VERSION'`) so it isn't expanded early.
-
-Symlinking alone only makes a package *discoverable* - it still needs to be required by name in `ADDITIONAL_PACKAGES` (or `SITEPACKAGE_PACKAGES`) to actually get installed and activated, the same way the default `test/sitepackage` fixture works.
-
-### Install hooks
-
-For install steps that don't fit a variable in `project.sh`, add a script at `.ddev/.setup/hooks/<name>.sh` - it's sourced automatically if present, so it has access to `$VERSION`, `$BASE_PATH`, `$TYPO3_BIN`, `$DATABASE`, `$EXTENSION_KEY` and the `message`/`_progress`/`_done` helpers. Unlike the best-effort `Tests/Acceptance/Fixtures/*.sh` scripts, a failing command in a hook aborts the install with its output shown, not silently swallowed.
-
-| Hook | Runs |
-|---|---|
-| `pre-install` | Before the environment is set up (`$TYPO3_BIN`/`$DATABASE` are not yet available at this point) |
-| `post-composer` | After the base composer packages are installed |
-| `post-typo3-setup` | After TYPO3 itself is set up, before fixture import |
-| `post-install` | Last, after fixtures, site configs and the schema update |
-
-### Avoiding CS-fixer churn on `.ddev/`
-
-If your project runs `php-cs-fixer` (or a similar tool) on the whole repository, it will also reformat the files this add-on manages under `.ddev/` to match *your* project's rules - which may differ from the rules this add-on's own files were written with. That produces a spurious diff on every `ddev add-on get` update, and every `composer cgl`/fixer run dirties files that aren't supposed to be edited locally anyway. Exclude `.ddev/` from your fixer's paths to avoid this:
-
-```php
-$finder = (new PhpCsFixer\Finder())
-    ->in(__DIR__)
-    ->exclude('.ddev');
-```
-
-### Application context
-
-Every installed instance runs with `TYPO3_CONTEXT=Development`, set via `docker-compose.typo3-setup.yaml`. `ddev config --web-environment-add=TYPO3_CONTEXT=Production` does **not** override it - add-on-provided compose files are merged after DDEV's own config-derived one, so the add-on's value always wins. To override it, add your own compose file that sorts after `docker-compose.typo3-setup.yaml` (survives `ddev add-on get` updates, since it isn't a file the add-on manages):
-
-```yaml
-# .ddev/docker-compose.zz-context-override.yaml
-services:
-  web:
-    environment:
-      - TYPO3_CONTEXT=Production
-```
-
-Then run `ddev restart` to apply it.
-
-### Fixtures
-
-During installation, fixture data from `Tests/Acceptance/Fixtures/` is automatically imported. The following types are supported:
-
-| Type | Location | Description |
-|------|----------|-------------|
-| XML | `Tests/Acceptance/Fixtures/*.xml` | TYPO3 export files, imported via `impexp:import` |
-| SQL | `Tests/Acceptance/Fixtures/*.sql` | Raw SQL files, imported directly into the database |
-| Site config | `Tests/Acceptance/Fixtures/sites/<site-name>/` | Site configuration directories copied to `config/sites/`. In `config.yaml`, `__VERSION__` is replaced with the TYPO3 version and `__SITENAME__` with the project's `DDEV_SITENAME`. Use a relative `base: /` - an absolute hostname in `base` breaks as soon as the project's hostname changes (e.g. in a `git worktree` checkout). The older `VERSION_PLACEHOLDER` placeholder still works but is deprecated in favor of `__VERSION__`. |
-| Shell scripts | `Tests/Acceptance/Fixtures/*.sh` | Executed during setup (failures are logged but don't abort the installation) |
-
-## 🧩 Classic mode (non-Composer)
-
-Most extensions on the TER are installed in **classic mode** (non-Composer), where TYPO3
-resolves classes from the `autoload` key in `ext_emconf.php` instead of Composer's PSR-4
-autoloader. Bugs that only surface there — a missing or drifted `ext_emconf.php` autoload
-key, an extension key mismatch, or a runtime dependency that only exists because Composer
-happened to pull it in — stay invisible in the default Composer-mode instances.
-
-Append `--classic` to an install to (re)build that version as a Composer-free instance:
-
-    ddev install 13 --classic
-
-This **replaces the version 13 slot in place**: TYPO3 sources are downloaded from
-`get.typo3.org` (no `composer install`), your extension is symlinked into
-`typo3conf/ext/<extension_key>` and activated the classic way — exactly like on the TER.
-On TYPO3 v12/v13, class loading is driven by the `autoload` key in `ext_emconf.php`;
-on TYPO3 v14, classic mode requires a `composer.json` in the extension instead. The
-instance keeps the same hostname:
-
-    https://13.<extension-name>.ddev.site
-
-The regular commands detect the mode automatically:
-
-    ddev 13 typo3 cache:flush
-    ddev launch 13
-
-To switch back to a Composer instance, re-run the install without the flag:
-
-    ddev install 13
-
-### Non-core Composer dependencies
-
-If your extension requires a package TYPO3 core doesn't already ship (e.g. `symfony/var-dumper`),
-classic mode has no `vendor/` to resolve it from — the class simply won't be found at runtime.
-Bundle such dependencies into your extension with
-[`eliashaeussler/typo3-vendor-bundler`](https://github.com/eliashaeussler/typo3-vendor-bundler)
-before testing classic mode; the [reusable release workflow](https://github.com/konradmichalik/reusable-github-actions)
-mirrors the same bundling step for TER releases.
-
-### Fixture packages without `ext_emconf.php`
-
-TYPO3's classic-mode package discovery only recognizes directories containing an `ext_emconf.php`.
-The default `sitepackage` fixture (and any project fixture under `Tests/Acceptance/Fixtures/packages/`)
-ships only a `composer.json`, so this add-on generates a minimal `ext_emconf.php` for it automatically
-in classic mode - the fixture's own source files are never modified.
-
-**Notes**
-
-- A version slot is either Composer or classic at a time, not both — rebuild to switch.
-  Different versions can still run in different modes side by side (e.g. Composer 13 and
-  classic 14).
-- Classic mode is **per version** and is not part of `ddev install all`.
-- Only TYPO3 v12+ is supported in classic mode.
-- On TYPO3 v14, classic mode only recognises extensions that ship a `composer.json` —
-  make sure your extension provides one before testing v14 in classic mode.
-- `composer` commands (`ddev 13 composer ...`) are unavailable while a slot is in classic mode.
-
-## 📊 Usage
-
-You can launch a TYPO3 instance in your browser with the following command:
-
-```shell
-ddev launch 11
-ddev launch 12
-ddev launch 13
-ddev launch 14
-```
-
-If you want to open the TYPO3 backend directly, use the following command:
-
-```shell
-ddev launch 13 /typo3
-```
-
-If you want to execute a console command in a specific TYPO3 instance, use the following command:
-
-```shell
-ddev 11 composer update
-ddev 12 typo3 cache:flush
-ddev 13 ls -la
-```
-
-You can also run a command in all TYPO3 instances at once:
-
-```shell
-ddev all typo3 cache:flush
-```
-
-## 🌳 Git Worktree Support
-
-Since `.ddev/` is committed to your repository, a plain `git worktree add` checkout would normally share the same DDEV project name (and therefore the same hostnames) as your primary checkout - only one of them could run at a time. This add-on avoids baking the project name into any of its own files, but DDEV's own `.ddev/config.yaml` still needs one adjustment, and each worktree needs its own hostnames.
-
-Requires DDEV `>= v1.24.10` (the version constraint declared by this add-on).
-
-### One-time setup
-
-Tell DDEV to derive the project name from the directory instead of a fixed `name:` in `.ddev/config.yaml` - either per project by removing the `name:` line from `.ddev/config.yaml`, or globally for all future projects:
-
-```shell
-ddev config global --omit-project-name-by-default=true
-```
-
-### Per-worktree setup
-
-Create the worktree as a **sibling** of your primary checkout (never nested inside it), using a directory name that's safe as a DNS label (lowercase letters, digits, hyphens):
-
-```shell
-git worktree add ../my-feature-branch feature/my-feature
-cd ../my-feature-branch
-ddev worktree-init
-ddev restart
 ddev install all
+ddev launch
 ```
 
-`ddev worktree-init` regenerates this checkout's router hostnames so they don't collide with the primary checkout's; `.Build/` is gitignored, so every worktree needs its own `ddev install`.
+That installs a blank TYPO3 instance for every configured version and opens
+the intro page, which links to each running instance.
 
-> [!NOTE]
-> A bare `404 page not found` right after `ddev restart` is the ddev **router**, not TYPO3 - registering a new project while others are already running can leave the router without a route for it until the project is restarted once more. Run `ddev restart` again if you see it.
+![Screencast](./images/screencast.gif)
 
-A new worktree checkout initially contains only committed repository content. If a repo-owned customization file such as `.ddev/.setup/project.sh` or a script under `.ddev/.setup/hooks/` isn't committed, a new worktree simply won't have it - no error, the customization just doesn't apply.
+## ⚡ Usage
 
-### Resource expectations
+| Command | Does |
+|---|---|
+| `ddev install [version\|all] [-v] [--demo[=profile]] [--classic]` | Install or rebuild one or all TYPO3 instances |
+| `ddev launch [version] [/path]` | Open an instance in the browser |
+| `ddev <version> <command>` | Run a command inside one instance, e.g. `ddev 13 typo3 cache:flush` |
+| `ddev all <command>` | Run a command in every installed instance |
+| `ddev worktree-init` | Regenerate hostnames for a git worktree checkout |
+| `ddev worktree-remove` | Tear down a worktree's DDEV project |
 
-Each worktree runs its own `web` and `db` container, plus roughly one full TYPO3 distribution per configured version under `.Build/`. Running several worktrees at once multiplies both. `ddev poweroff` stops *all* DDEV projects, not just the current one - worth knowing if several worktrees (or agents) are meant to keep running in parallel.
+Full flags, exit behaviour and examples for every command are in [docs/installation.md](docs/installation.md) and [docs/commands.md](docs/commands.md).
 
-### Removing a worktree
+## 🏗️ Architecture
 
-From inside the worktree, `ddev worktree-remove` unregisters its DDEV project and drops its database, images and volumes, then prints the `git worktree remove` / `git branch -D` commands to run from your **primary** checkout (a worktree cannot remove itself while you're inside it).
-
-### Upgrading an existing project
-
-If you installed this add-on before worktree support was added, re-run the installation command to pick up the fixes:
-
-```shell
-ddev add-on get konradmichalik/ddev-typo3-multi-version-extension && ddev restart
-```
-
-See [Updating](#updating) above for which files get overwritten.
-
-## Background
-
-The TYPO3 instances are located in the `.Build/` directory. The main extension is symlinked from the root directory to the `.Build/` directory. 
+Each TYPO3 instance lives in its own subdirectory of `.Build/`, with the main
+extension symlinked in from the project root:
 
 ```text
 .
 └── .Build/
-    ├── 11/
+    ├── 12/
     │   ├── config/
     │   ├── packages/
     │   │   ├── sitepackage/
@@ -326,4 +87,27 @@ The TYPO3 instances are located in the `.Build/` directory. The main extension i
     └── ...
 ```
 
-**Contributed and maintained by `@konradmichalik`**
+`.Build/` is gitignored - every checkout (including every git worktree) runs
+its own `ddev install`.
+
+## 📚 Documentation
+
+| Topic | What's inside |
+|-------|---------------|
+| [Installing instances](docs/installation.md) | Every `ddev install` flag: versions, `--classic`, `--demo[=profile]`, `-v/--verbose` |
+| [Commands](docs/commands.md) | `ddev launch`, running commands per version or across all instances, worktree commands |
+| [Configuration](docs/configuration.md) | `project.sh` variables, install hooks, fixtures, symlink exclusions, application context, CS-fixer exclusion |
+| [Classic mode](docs/classic-mode.md) | Rebuilding a version as a non-Composer, TER-style install |
+| [Git worktrees](docs/git-worktrees.md) | Running several checkouts of the same repository side by side |
+
+## 🧑‍💻 Contributing
+
+Please have a look at [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## 💎 Credits
+
+Contributed and maintained by [`@konradmichalik`](https://github.com/konradmichalik).
+
+## ⭐ License
+
+This project is licensed under [Apache-2.0](LICENSE).

--- a/docs/classic-mode.md
+++ b/docs/classic-mode.md
@@ -1,0 +1,72 @@
+# Classic mode (non-Composer)
+
+Most extensions on the TER are installed in **classic mode** (non-Composer),
+where TYPO3 resolves classes from the `autoload` key in `ext_emconf.php`
+instead of Composer's PSR-4 autoloader. Bugs that only surface there - a
+missing or drifted `ext_emconf.php` autoload key, an extension key mismatch,
+or a runtime dependency that only exists because Composer happened to pull it
+in - stay invisible in the default Composer-mode instances.
+
+Append `--classic` to [`ddev install`](installation.md#--classic) to (re)build
+that version as a Composer-free instance:
+
+```shell
+ddev install 13 --classic
+```
+
+This **replaces the version 13 slot in place**: TYPO3 sources are downloaded
+from `get.typo3.org` (no `composer install`), your extension is symlinked
+into `typo3conf/ext/<extension_key>` and activated the classic way - exactly
+like on the TER. On TYPO3 v12/v13, class loading is driven by the `autoload`
+key in `ext_emconf.php`; on TYPO3 v14, classic mode requires a `composer.json`
+in the extension instead. The instance keeps the same hostname:
+
+```text
+https://13.<extension-name>.ddev.site
+```
+
+The regular commands detect the mode automatically:
+
+```shell
+ddev 13 typo3 cache:flush
+ddev launch 13
+```
+
+To switch back to a Composer instance, re-run the install without the flag:
+
+```shell
+ddev install 13
+```
+
+## Non-core Composer dependencies
+
+If your extension requires a package TYPO3 core doesn't already ship (e.g.
+`symfony/var-dumper`), classic mode has no `vendor/` to resolve it from - the
+class simply won't be found at runtime. Bundle such dependencies into your
+extension with
+[`eliashaeussler/typo3-vendor-bundler`](https://github.com/eliashaeussler/typo3-vendor-bundler)
+before testing classic mode; the
+[reusable release workflow](https://github.com/konradmichalik/reusable-github-actions)
+mirrors the same bundling step for TER releases.
+
+## Fixture packages without `ext_emconf.php`
+
+TYPO3's classic-mode package discovery only recognizes directories containing
+an `ext_emconf.php`. The default `sitepackage` fixture (and any project
+fixture under `Tests/Acceptance/Fixtures/packages/`) ships only a
+`composer.json`, so this add-on generates a minimal `ext_emconf.php` for it
+automatically in classic mode - the fixture's own source files are never
+modified.
+
+## Notes
+
+- A version slot is either Composer or classic at a time, not both - rebuild
+  to switch. Different versions can still run in different modes side by side
+  (e.g. Composer 13 and classic 14).
+- Classic mode is **per version** and is not part of `ddev install all`.
+- Only TYPO3 v12+ is supported in classic mode.
+- On TYPO3 v14, classic mode only recognises extensions that ship a
+  `composer.json` - make sure your extension provides one before testing v14
+  in classic mode.
+- `composer` commands (`ddev 13 composer ...`) are unavailable while a slot is
+  in classic mode.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,71 @@
+# Instance commands
+
+Commands for working with instances once they are installed. For creating or
+rebuilding an instance, see [`ddev install`](installation.md).
+
+## `ddev launch [<version>] [<path>]`
+
+Opens a browser at an instance's URL. Starts the project first if it is not
+already running.
+
+```shell
+ddev launch
+ddev launch 13
+ddev launch 13 /typo3
+```
+
+With no version, opens the project's primary URL (the intro page). With a
+version but no path, opens that instance's homepage. `<path>` is appended to
+the instance URL, so `ddev launch 13 /typo3` opens the TYPO3 13 backend
+directly.
+
+## `ddev <version> <command>`
+
+Runs `<command>` inside one instance's directory. `typo3 …` is rewritten to
+the right binary for that version and mode automatically (`vendor/bin/typo3`
+for Composer instances, `vendor/bin/typo3cms` on TYPO3 11, the core CLI binary
+for classic instances).
+
+```shell
+ddev 11 composer du -o
+ddev 12 typo3 cache:flush
+ddev 13 ls -la
+```
+
+`composer` commands are rejected for a slot currently rebuilt in
+[classic mode](classic-mode.md), since a classic instance has no `vendor/`.
+
+## `ddev all <command>`
+
+Runs `<command>` in every installed instance listed in `TYPO3_VERSIONS`, one
+after another. Each instance is skipped with a warning if it has not been
+installed yet.
+
+```shell
+ddev all composer du -o
+ddev all typo3 cache:flush
+```
+
+## `ddev worktree-init`
+
+Regenerates this checkout's router hostnames so a `git worktree` checkout does
+not collide with the primary checkout's. Run once per worktree, right after
+`ddev config global --omit-project-name-by-default=true` and before the first
+`ddev restart`. See [Git worktrees](git-worktrees.md) for the full setup.
+
+```shell
+ddev worktree-init
+ddev restart
+ddev install all
+```
+
+## `ddev worktree-remove`
+
+Unregisters this worktree's DDEV project and drops its database, images and
+volumes, then prints the `git worktree remove` / `git branch -D` commands to
+run from the **primary** checkout - a worktree cannot remove itself while you
+are inside it.
+
+```shell
+ddev worktree-remove
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,136 @@
+# Configuration
+
+By default, a blank TYPO3 instance is installed for each version, with only
+two extensions active:
+
+- your **main extension** from the project root (symlinked)
+- a demo **sitepackage extension** from `Tests/Acceptance/Fixtures/packages`
+
+Use the sitepackage to exercise your main extension's features. Adjust it to
+your needs in `Tests/Acceptance/Fixtures/packages/sitepackage/`.
+
+If you need more extensions, place them in `Tests/Acceptance/Fixtures/packages`
+or adjust the `ddev install` command - within e.g. the
+[`.install-12`](../commands/web/.install-12) file, you can adjust the
+`composer require` command to fit your needs.
+
+## `TYPO3_VERSIONS`
+
+`TYPO3 12`, `13` and `14` are installed by `ddev install all` by default.
+TYPO3 11 is still fully supported by the install scripts but is not part of
+that default set. Edit the `TYPO3_VERSIONS` variable in
+[`.ddev/docker-compose.typo3-setup.yaml`](../docker-compose.typo3-setup.yaml)
+to drop versions you don't need, or add `11` back:
+
+```yaml
+- TYPO3_VERSIONS=11 12 13 14
+```
+
+Run `ddev restart` after changing it.
+
+## `SYMLINK_EXCLUSIONS`
+
+Items from your main extension's root directory are symlinked into each TYPO3
+instance, except the ones listed in `SYMLINK_EXCLUSIONS` in
+[`docker-compose.typo3-setup.yaml`](../docker-compose.typo3-setup.yaml). It
+defaults to `Documentation Documentation-GENERATED-temp var vendor public`, so
+a local `vendor/` or `public/` directory in your extension repository is not
+linked into the instance's own composer/web-root structure.
+
+## `project.sh`
+
+Copy [`.ddev/.setup/project.sh.example`](../.setup/project.sh.example) to
+`.ddev/.setup/project.sh` to customize the install without touching
+`utils.sh` - `project.sh` isn't managed by the add-on, so it survives
+`ddev add-on get` upgrades.
+
+```bash
+ADDITIONAL_PACKAGES=(
+    'typo3/cms-reports:^$VERSION'
+)
+```
+
+| Variable | Effect |
+|---|---|
+| `ADDITIONAL_PACKAGES` | Extra composer packages installed alongside the base install |
+| `SITEPACKAGE_PACKAGES` | Replaces the default `test/sitepackage` when set |
+| `COMPOSER_CONFIG` | Extra `composer config` entries |
+| `TYPO3_SETTINGS` | Extra `typo3 configuration:set` calls |
+| `FIXTURE_EXTENSION_DIRS` | Extra directories (besides `Tests/Acceptance/Fixtures/packages`) whose subdirectories get symlinked into Composer's local package repository |
+
+`$VERSION` in a package constraint expands per version at install time - write
+it single-quoted (e.g. `'typo3/cms-reports:^$VERSION'`) so it isn't expanded
+early.
+
+Symlinking alone only makes a package *discoverable* - it still needs to be
+required by name in `ADDITIONAL_PACKAGES` (or `SITEPACKAGE_PACKAGES`) to
+actually get installed and activated, the same way the default
+`test/sitepackage` fixture works.
+
+## Install hooks
+
+For install steps that don't fit a `project.sh` variable, add a script at
+`.ddev/.setup/hooks/<name>.sh` - it's sourced automatically if present, so it
+has access to `$VERSION`, `$BASE_PATH`, `$TYPO3_BIN`, `$DATABASE`,
+`$EXTENSION_KEY` and the `message`/`_progress`/`_done` helpers. Unlike the
+best-effort `Tests/Acceptance/Fixtures/*.sh` scripts below, a failing command
+in a hook aborts the install with its output shown, not silently swallowed.
+
+| Hook | Runs |
+|---|---|
+| `pre-install` | Before the environment is set up (`$TYPO3_BIN`/`$DATABASE` are not yet available at this point) |
+| `post-composer` | After the base composer packages are installed |
+| `post-typo3-setup` | After TYPO3 itself is set up, before fixture import |
+| `post-install` | Last, after fixtures, site configs and the schema update |
+
+```bash
+# .ddev/.setup/hooks/post-install.sh
+$TYPO3_BIN extension:setup --extension=my_extension
+```
+
+## Fixtures
+
+During installation, fixture data from `Tests/Acceptance/Fixtures/` is
+imported automatically:
+
+| Type | Location | Description |
+|------|----------|--------------|
+| XML | `Tests/Acceptance/Fixtures/*.xml` | TYPO3 export files, imported via `impexp:import` |
+| SQL | `Tests/Acceptance/Fixtures/*.sql` | Raw SQL files, imported directly into the database |
+| Site config | `Tests/Acceptance/Fixtures/sites/<site-name>/` | Site configuration directories copied to `config/sites/`. In `config.yaml`, `__VERSION__` is replaced with the TYPO3 version and `__SITENAME__` with the project's `DDEV_SITENAME`. Use a relative `base: /` - an absolute hostname in `base` breaks as soon as the project's hostname changes (e.g. in a `git worktree` checkout). The older `VERSION_PLACEHOLDER` placeholder still works but is deprecated in favor of `__VERSION__`. |
+| Shell scripts | `Tests/Acceptance/Fixtures/*.sh` | Executed during setup (failures are logged but don't abort the installation) |
+
+## Application context
+
+Every installed instance runs with `TYPO3_CONTEXT=Development`, set via
+`docker-compose.typo3-setup.yaml`. `ddev config --web-environment-add=TYPO3_CONTEXT=Production`
+does **not** override it - add-on-provided compose files are merged after
+DDEV's own config-derived one, so the add-on's value always wins. To override
+it, add your own compose file that sorts after `docker-compose.typo3-setup.yaml`
+(survives `ddev add-on get` updates, since it isn't a file the add-on manages):
+
+```yaml
+# .ddev/docker-compose.zz-context-override.yaml
+services:
+  web:
+    environment:
+      - TYPO3_CONTEXT=Production
+```
+
+Then run `ddev restart` to apply it.
+
+## Avoiding CS-fixer churn on `.ddev/`
+
+If your project runs `php-cs-fixer` (or a similar tool) on the whole
+repository, it will also reformat the files this add-on manages under
+`.ddev/` to match *your* project's rules - which may differ from the rules
+this add-on's own files were written with. That produces a spurious diff on
+every `ddev add-on get` update, and every `composer cgl`/fixer run dirties
+files that aren't supposed to be edited locally anyway. Exclude `.ddev/` from
+your fixer's paths to avoid this:
+
+```php
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('.ddev');
+```

--- a/docs/git-worktrees.md
+++ b/docs/git-worktrees.md
@@ -1,0 +1,76 @@
+# Git worktree support
+
+Since `.ddev/` is committed to your repository, a plain `git worktree add`
+checkout would normally share the same DDEV project name (and therefore the
+same hostnames) as your primary checkout - only one of them could run at a
+time. This add-on avoids baking the project name into any of its own files,
+but DDEV's own `.ddev/config.yaml` still needs one adjustment, and each
+worktree needs its own hostnames.
+
+Requires DDEV `>= v1.24.10` (the version constraint declared by this add-on).
+
+## One-time setup
+
+Tell DDEV to derive the project name from the directory instead of a fixed
+`name:` in `.ddev/config.yaml` - either per project by removing the `name:`
+line from `.ddev/config.yaml`, or globally for all future projects:
+
+```shell
+ddev config global --omit-project-name-by-default=true
+```
+
+## Per-worktree setup
+
+Create the worktree as a **sibling** of your primary checkout (never nested
+inside it), using a directory name that's safe as a DNS label (lowercase
+letters, digits, hyphens):
+
+```shell
+git worktree add ../my-feature-branch feature/my-feature
+cd ../my-feature-branch
+ddev worktree-init
+ddev restart
+ddev install all
+```
+
+[`ddev worktree-init`](commands.md#ddev-worktree-init) regenerates this
+checkout's router hostnames so they don't collide with the primary checkout's;
+`.Build/` is gitignored, so every worktree needs its own `ddev install`.
+
+> [!NOTE]
+> A bare `404 page not found` right after `ddev restart` is the DDEV
+> **router**, not TYPO3 - registering a new project while others are already
+> running can leave the router without a route for it until the project is
+> restarted once more. Run `ddev restart` again if you see it.
+
+A new worktree checkout initially contains only committed repository content.
+If a repo-owned customization file such as `.ddev/.setup/project.sh` or a
+script under `.ddev/.setup/hooks/` isn't committed, a new worktree simply
+won't have it - no error, the customization just doesn't apply.
+
+## Resource expectations
+
+Each worktree runs its own `web` and `db` container, plus roughly one full
+TYPO3 distribution per configured version under `.Build/`. Running several
+worktrees at once multiplies both. `ddev poweroff` stops *all* DDEV projects,
+not just the current one - worth knowing if several worktrees (or agents) are
+meant to keep running in parallel.
+
+## Removing a worktree
+
+From inside the worktree,
+[`ddev worktree-remove`](commands.md#ddev-worktree-remove) unregisters its
+DDEV project and drops its database, images and volumes, then prints the
+`git worktree remove` / `git branch -D` commands to run from your **primary**
+checkout (a worktree cannot remove itself while you're inside it).
+
+## Upgrading an existing project
+
+If you installed this add-on before worktree support was added, re-run the
+installation command to pick up the fixes:
+
+```shell
+ddev add-on get konradmichalik/ddev-typo3-multi-version-extension && ddev restart
+```
+
+See [Updating](../README.md#updating) for which files get overwritten.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,74 @@
+# Console command `ddev install`
+
+```shell
+ddev install [<version>|all] [-v|--verbose] [--demo[=<profile>]] [--classic]
+```
+
+Installs a fresh TYPO3 instance for the given version, or rebuilds it if one
+already exists in that slot. With no version argument, the lowest version in
+`TYPO3_VERSIONS` is used (see [Configuration](configuration.md)).
+
+Each Composer-mode install: wipes `.Build/<version>/`, symlinks the main
+extension and the fixture packages from `Tests/Acceptance/Fixtures/packages/`
+into it, runs `composer req typo3/cms-base-distribution:^<version>` plus the
+sitepackage and any `ADDITIONAL_PACKAGES`, sets up TYPO3 non-interactively,
+imports fixtures, and runs the schema update. Any repo-owned
+[install hook](configuration.md#install-hooks) runs at the matching point in
+that sequence.
+
+## `<version>|all`
+
+The TYPO3 major to install: `11`, `12`, `13` or `14`. `all` installs every
+version listed in `TYPO3_VERSIONS`.
+
+```shell
+ddev install 13
+ddev install all
+```
+
+Requesting a version that is not in `TYPO3_VERSIONS` fails with
+`TYPO3 version '<version>' is not supported.` before anything is touched.
+
+## `-v`, `--verbose`
+
+Streams the full output of every install step instead of showing a spinner.
+Useful when an install fails and the default spinner mode's captured log is
+not enough context.
+
+```shell
+ddev install 12 -v
+```
+
+## `--demo[=<profile>]`
+
+Populates the instance with a demo site instead of a single blank page. The
+demo step always drops and rebuilds the instance rather than layering onto an
+existing one, so re-running it is deterministic.
+
+```shell
+ddev install 13 --demo
+ddev install 13 --demo=bootstrap
+ddev install all --demo
+```
+
+| Profile | Result |
+|---|---|
+| `introduction` (default) | Installs [`typo3/cms-introduction`](https://extensions.typo3.org/extension/introduction) and removes the generated `main` site, since the Introduction Package brings its own. **Not available on TYPO3 14** - no released version supports it yet, so `--demo`/`--demo=introduction` automatically falls back to `bootstrap` on 14 with a warning message. |
+| `bootstrap` | Installs [`bk2k/bootstrap-package`](https://packagist.org/packages/bk2k/bootstrap-package) only - a themed but otherwise empty site. Works on every supported version. |
+| `custom` | Installs no demo package; relies entirely on your own `Tests/Acceptance/Fixtures/` fixtures. |
+
+## `--classic`
+
+Rebuilds the given version as a Composer-free (TER-style) instance instead of
+the default Composer instance. See [Classic mode](classic-mode.md) for what
+changes and its limitations.
+
+```shell
+ddev install 13 --classic
+```
+
+`--classic` cannot be combined with `all` (`Classic mode is per-version only`)
+and is rejected for version `11` (`Classic mode requires TYPO3 v12 or higher.`).
+
+To switch a slot back to a Composer instance, re-run the install without the
+flag: `ddev install 13`.


### PR DESCRIPTION
## Summary

- Rewrite README.md to a shorter overview: why-paragraph, feature list, quick start, command table, architecture, documentation index
- Move detailed reference material (install flags, demo profiles, project.sh variables, install hooks, fixtures, classic mode, git worktree support) into dedicated `docs/` pages
- Correct a stale claim: the README listed TYPO3 11.5/12.4/13.4/14.3 as supported; the default `TYPO3_VERSIONS` in `docker-compose.typo3-setup.yaml` is actually `12 13 14` (11 was dropped when 14 was added), and the composer constraint (`^$VERSION`) always resolves to the latest patch rather than a pinned one — the docs now state majors only and note that TYPO3 11 is opt-in
- Add `CONTRIBUTING.md` (local setup against a real DDEV project, running the bats test suite, commit convention) since the README now links to it
- Exclude `docs/` from release tarballs via `.gitattributes`

## Changes

- `README.md` - trimmed to overview + links into `docs/`
- `docs/installation.md` - full `ddev install` flag reference (`--classic`, `--demo[=profile]`, `-v`)
- `docs/commands.md` - `ddev launch`, per-version exec, `ddev all`, worktree commands
- `docs/configuration.md` - `project.sh` variables, install hooks, fixtures, symlink exclusions, application context, CS-fixer exclusion
- `docs/classic-mode.md` - non-Composer (TER-style) instance mode
- `docs/git-worktrees.md` - running multiple checkouts side by side
- `CONTRIBUTING.md` - new
- `.gitattributes` - exclude `docs/` from release tarballs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for installation, configuration, commands, classic mode, Git worktrees, testing, and contribution workflows.
  * Streamlined the README with supported versions, requirements, features, quick-start instructions, and links to detailed documentation.
* **Chores**
  * Documentation files are excluded from release archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->